### PR TITLE
improve error msgs and *-set-field methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - [#61](https://github.com/wandersoncferreira/code-review/pull/61): allow approve PR without feedback comment
 - [#63](https://github.com/wandersoncferreira/code-review/pull/63): add naive progress reporter
 - [#66](https://github.com/wandersoncferreira/code-review/pull/66): improve error message when personal token is not set
+- [#67](https://github.com/wandersoncferreira/code-review/pull/67): improve error messages and `code-review-set-*` functions with proper callbacks

--- a/code-review-core.el
+++ b/code-review-core.el
@@ -63,26 +63,26 @@
 (cl-defgeneric code-review-core-get-labels (obj)
   "Sync call to get a list of labels from OBJ.")
 
-(cl-defgeneric code-review-core-set-labels (obj)
-  "Sync call to set a list of labels for an OBJ.")
+(cl-defgeneric code-review-core-set-labels (obj callback)
+  "Sync call to set a list of labels for an OBJ and call CALLBACK afterward..")
 
 (cl-defgeneric code-review-core-get-assignees (obj)
   "Sync call to get a list of assignees from OBJ.")
 
-(cl-defgeneric code-review-core-set-assignee (obj)
-  "Set an assignee for an OBJ.")
+(cl-defgeneric code-review-core-set-assignee (obj callback)
+  "Set an assignee for an OBJ and call CALLBACK afterward..")
 
 (cl-defgeneric code-review-core-get-milestones (obj)
   "Sync call to get a list of milestones from OBJ.")
 
-(cl-defgeneric code-review-core-set-milestone (obj)
-  "Set a milestone for an OBJ.")
+(cl-defgeneric code-review-core-set-milestone (obj callback)
+  "Set a milestone for an OBJ and call CALLBACK afterward.")
 
-(cl-defgeneric code-review-core-set-title (obj)
-  "Set a pullrequest title for an OBJ.")
+(cl-defgeneric code-review-core-set-title (obj callback)
+  "Set a pullrequest title for an OBJ and call CALLBACK afterward.")
 
-(cl-defgeneric code-review-core-set-description (obj)
-  "Set a pullrequest description for an OBJ.")
+(cl-defgeneric code-review-core-set-description (obj callback)
+  "Set a pullrequest description for an OBJ and call CALLBACK afterward.")
 
 (cl-defgeneric code-review-core-merge (obj strategy)
   "Merge a PR for an OBJ using a given STRATEGY.")

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -376,10 +376,12 @@ Milestones, labels, projects, and more."
                   (oref obj labels))))
     (setq code-review-comment-cursor-pos (point))
     (oset obj labels labels)
-    (code-review-core-set-labels obj)
-    (closql-insert (code-review-db) obj t)
-    (code-review--build-buffer
-     (code-review-utils-current-project-buffer-name))))
+    (code-review-core-set-labels
+     obj
+     (lambda ()
+       (closql-insert (code-review-db) obj t)
+       (code-review--build-buffer
+        (code-review-utils-current-project-buffer-name))))))
 
 (defun code-review-utils--set-assignee-field (obj &optional assignee)
   "Helper function to set assignees header field given an OBJ.
@@ -391,10 +393,12 @@ If a valid ASSIGNEE is provided, use that instead."
              (choice (completing-read "Choose: " options)))
         (setq candidate choice)))
     (oset obj assignees (list `((name) (login . ,candidate))))
-    (code-review-core-set-assignee obj)
-    (closql-insert (code-review-db) obj t)
-    (code-review--build-buffer
-     (code-review-utils-current-project-buffer-name))))
+    (code-review-core-set-assignee
+     obj
+     (lambda ()
+       (closql-insert (code-review-db) obj t)
+       (code-review--build-buffer
+        (code-review-utils-current-project-buffer-name))))))
 
 (defun code-review-utils--set-milestone-field (obj)
   "Helper function to set a milestone given an OBJ."
@@ -405,29 +409,35 @@ If a valid ASSIGNEE is provided, use that instead."
                       (number .,(alist-get choice options nil nil 'equal)))))
     (setq code-review-comment-cursor-pos (point))
     (oset obj milestones milestone)
-    (code-review-core-set-milestone obj)
-    (closql-insert (code-review-db) obj t)
-    (code-review--build-buffer
-     (code-review-utils-current-project-buffer-name))))
+    (code-review-core-set-milestone
+     obj
+     (lambda ()
+       (closql-insert (code-review-db) obj t)
+       (code-review--build-buffer
+        (code-review-utils-current-project-buffer-name))))))
 
 (defun code-review-utils--set-title-field (title)
   "Helper function to set a TITLE."
   (let ((pr (code-review-db-get-pullreq)))
     (setq code-review-comment-cursor-pos (point))
     (oset pr title title)
-    (code-review-core-set-title pr)
-    (closql-insert (code-review-db) pr t)
-    (code-review--build-buffer
-     code-review-buffer-name)))
+    (code-review-core-set-title
+     pr
+     (lambda ()
+       (closql-insert (code-review-db) pr t)
+       (code-review--build-buffer
+        code-review-buffer-name)))))
 
 (defun code-review-utils--set-description-field (description)
   "Helper function to set a DESCRIPTION."
   (let ((pr (code-review-db-get-pullreq)))
     (oset pr description description)
-    (code-review-core-set-description pr)
-    (closql-insert (code-review-db) pr t)
-    (code-review--build-buffer
-     code-review-buffer-name)))
+    (code-review-core-set-description
+     pr
+     (lambda ()
+       (closql-insert (code-review-db) pr t)
+       (code-review--build-buffer
+        code-review-buffer-name)))))
 
 (defun code-review-utils--set-feedback-field (feedback)
   "Helper function to set a FEEDBACK."


### PR DESCRIPTION
The `code-review-set-*` functions didn't check the response from the provider before re-rendering the PR buffer. This might cause some issues. Now it does check if the call was successful or not.