### PR TITLE
show CI status on Github PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - [#96](https://github.com/wandersoncferreira/code-review/pull/96/files): render comments using HTML to allow displaying images.
+- [#98](https://github.com/wandersoncferreira/code-review/pull/98): add CI status on commits section. Demo [here](https://github.com/wandersoncferreira/code-review/pull/98).
 
 # v0.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Unreleased
 
 - [#96](https://github.com/wandersoncferreira/code-review/pull/96/files): render comments using HTML to allow displaying images.
-- [#98](https://github.com/wandersoncferreira/code-review/pull/98): add CI status on commits section. Demo [here](https://github.com/wandersoncferreira/code-review/pull/98).
+- [#98](https://github.com/wandersoncferreira/code-review/pull/98): add CI status on commits section. Github only. Demo [here](https://github.com/wandersoncferreira/code-review/pull/98).
 
 # v0.0.3
 

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -226,6 +226,39 @@ https://github.com/wandersoncferreira/code-review#configuration"))
           commit {
             abbreviatedOid
             message
+            statusCheckRollup {
+              state
+              contexts(first:50){
+                nodes {
+                  ... on CheckRun {
+                    startedAt
+                    completedAt
+                    name
+                    text
+                    title
+                    summary
+                    status
+                    conclusion
+                    detailsUrl
+                    checkSuite {
+                      app {
+                        id
+                        name
+                        description
+                        slug
+                        logoUrl
+                      }
+                      workflowRun {
+                        workflow
+                        {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -946,7 +946,8 @@ Optionally DELETE? flag must be set if you want to remove it."
                               (insert (propertize (format "%-7s %s / %s" "" .checkSuite.workflowRun.workflow.name .name)
                                                   'font-lock-face 'code-review-checker-name-face))
                               (insert " - ")
-                              (insert (propertize (format "%s  " (format "Successful in %s." "4s"))
+                              (insert (propertize (format "%s  " (format "Successful in %s."
+                                                                         (code-review-utils--elapsed-time .completedAt .startedAt)))
                                                   'font-lock-face 'magit-dimmed))
                               (insert (propertize ":white_check_mark: Details"
                                                   'font-lock-face 'code-review-checker-detail-face)))

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -502,6 +502,14 @@ Expect the same output as `git diff --no-prefix`"
   "Convert and format timestamp STR from json."
   (format-time-string "%b %d, %Y, %H:%M" (date-to-time str)))
 
+(defun code-review-utils--elapsed-time (t2 t1)
+  "Compute the elapsed time between T2 and T1."
+  (let ((res (- (time-to-seconds (date-to-time t2))
+                (time-to-seconds (date-to-time t1)))))
+    (if (> res 100)
+        (format "%smin" (/ res 60))
+      (format "%ss" res))))
+
 ;;; line-number-at-pos replacement
 ;; Function taken from https://emacs.stackexchange.com/questions/3821/a-faster-method-to-obtain-line-number-at-pos-in-large-buffers
 ;; nlinum.el

--- a/code-review.el
+++ b/code-review.el
@@ -237,17 +237,17 @@ If you want to display a minibuffer MSG in the end."
 (cl-defmethod code-review--internal-build ((_github code-review-github-repo) progress res &optional buff-name msg)
   "Helper function to build process for GITHUB based on the fetched RES informing PROGRESS."
   (let* ((raw-infos (a-get-in (-second-item res) (list 'data 'repository 'pullRequest))))
-    ;; 2. save raw diff data
+    ;; 1. save raw diff data
     (progress-reporter-update progress 3)
     (code-review-db--pullreq-raw-diff-update
      (code-review-utils--clean-diff-prefixes
       (a-get (-first-item res) 'message)))
 
-    ;; 2.1 save raw info data e.g. data from GraphQL API
+    ;; 1.1 save raw info data e.g. data from GraphQL API
     (progress-reporter-update progress 4)
     (code-review-db--pullreq-raw-infos-update raw-infos)
 
-    ;; 2.2 trigger renders
+    ;; 1.2 trigger renders
     (progress-reporter-update progress 5)
     (code-review--trigger-hooks buff-name msg)
     (progress-reporter-done progress)))

--- a/docs/forge_support.md
+++ b/docs/forge_support.md
@@ -20,5 +20,6 @@ Features supported by each integrated forge:
 | Request Reviewers              | x            |        |
 | Promote comment to issue       | x            |        |
 | Get/Visit binary files         | x            | x      |
+| CI status on commit section    | x            |        |
 
 


### PR DESCRIPTION
Fix #37 .
Demo of the feature:
![output-2021-12-06-23:36:46](https://user-images.githubusercontent.com/17708295/144955932-931ed15b-d8b2-4103-bf50-5c190e150e2b.gif)

`RET` on a checker line will take you to the web page with the details of the run.

