### PR TITLE
fix render html in gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#96](https://github.com/wandersoncferreira/code-review/pull/96/files): render comments using HTML to allow displaying images.
 - [#98](https://github.com/wandersoncferreira/code-review/pull/98): add CI status on commits section. Github only. Demo [here](https://github.com/wandersoncferreira/code-review/pull/98).
+- [#100](https://github.com/wandersoncferreira/code-review/pull/100): fix bug with Gitlab rendering comments with HTML.
 
 # v0.0.3
 

--- a/code-review-gitlab.el
+++ b/code-review-gitlab.el
@@ -304,7 +304,7 @@ repository:project(fullPath: \"%s\") {
           discussion {
             id
           }
-          bodyText: body
+          bodyHTML: bodyHtml
           author {
             login:username
           }
@@ -360,7 +360,7 @@ repository:project(fullPath: \"%s\") {
       }
       title
       state
-      bodyText: description
+      bodyHTML: descriptionHtml
     }
   }
 }

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1099,7 +1099,7 @@ INDENT count of spaces are added at the start of every line."
             (dolist (c thread-comments)
               (let* ((obj (code-review-comment-section
                            :author (a-get-in c (list 'author 'login))
-                           :msg (a-get c 'bodyText)
+                           :msg (a-get c 'bodyHTML)
                            :id (a-get c 'databaseId))))
                 (magit-insert-section (code-review-comment-section obj)
                   (insert (concat


### PR DESCRIPTION
Bug introduced after changing the rendering of comments to HTML.