### PR TITLE
set description field using text not html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#114](https://github.com/wandersoncferreira/code-review/pull/114): improve code structure.
 - [#118](https://github.com/wandersoncferreira/code-review/pull/118): add documentation to enterprise users
 - [#119](https://github.com/wandersoncferreira/code-review/pull/119): add feedback msg if no milestone is found
+- [#120](https://github.com/wandersoncferreira/code-review/pull/120): set description field using text not html
 
 # v0.0.3
 

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -180,7 +180,8 @@ Optionally define a MSG."
     (setq code-review-comment-cursor-pos (point-min))
     (with-current-buffer buffer
       (erase-buffer)
-      (insert (oref pr description))
+      (insert (-> (oref pr raw-infos)
+                  (a-get 'bodyText)))
       (insert ?\n)
       (switch-to-buffer-other-window buffer)
       (code-review-comment-mode))))
@@ -376,7 +377,9 @@ Optionally define a MSG."
         (kill-buffer-and-window)
         (cond
          (code-review-comment-description?
-          (oset pr description comment-text)
+          (oset pr raw-infos (-> (oref pr raw-infos)
+                                 (a-assoc 'bodyText comment-text)
+                                 (a-assoc 'bodyHTML nil)))
           (code-review-set-description
            pr
            (lambda ()

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -265,6 +265,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
       title
       state
       bodyHTML
+      bodyText
       reactions(first:50){
         nodes {
           id
@@ -449,7 +450,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
                       (oref github number))
               nil
               :auth 'code-review
-              :payload (a-alist 'body (oref github description))
+              :payload (a-alist 'body (a-get (oref github raw-infos) 'bodyText))
               :errorback #'code-review-github-errback
               :callback (lambda (&rest _) (funcall callback))))
 


### PR DESCRIPTION
After changing the render to HTML the description edition was expecting a HTML
body which is not ideal to type and actually not supported by the API