### PR TITLE
better UX to review comments!

### DIFF
--- a/code-review-faces.el
+++ b/code-review-faces.el
@@ -140,5 +140,10 @@
   "Face for outdated comments."
   :group 'code-review)
 
+(defface code-review-button-face
+  '((t :underline t :slant italic))
+  "Face used for buttons."
+  :group 'code-review)
+
 (provide 'code-review-faces)
 ;;; code-review-faces.el ends here

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -290,17 +290,23 @@ https://github.com/wandersoncferreira/code-review#configuration"))
           updatedAt
         }
       }
-      reviews(first: 50) {
+      reviews:reviewThreads(first: 50) {
         nodes {
           typename:__typename
-          author { login }
-          bodyHTML
-          state
-          createdAt
-          databaseId
-          updatedAt
+          isResolved
+          isOutdated
+          isCollapsed
+          resolvedBy {
+            login
+          }
           comments(first: 50) {
             nodes {
+              author {
+                login
+              }
+              pullRequestReview {
+                state
+              }
               createdAt
               updatedAt
               bodyHTML
@@ -713,6 +719,23 @@ Return the blob URL if BLOB? is provided."
              :payload (a-alist 'body comment-msg)
              :callback callback
              :errorback #'code-review-github-errback))
+
+(cl-defmethod code-review-resolve-thread ((github code-review-github-repo) thread-id)
+  "Resolve thread in GITHUB using THREAD-ID."
+  (let ((query "mutation($input: ResolveReviewThreadInput!) {
+  resolveReviewThread(input: $input) {
+    thread {
+      id
+    }
+  }
+}"))
+    (ghub-graphql query
+                  `((input . ((threadId . ,thread-id))))
+                  :auth 'code-review
+                  :host code-review-github-host
+                  :callback (lambda (&rest _)
+                              (message "Thread RESOLVED"))
+                  :errorback #'code-review-github-errback)))
 
 (provide 'code-review-github)
 ;;; code-review-github.el ends here


### PR DESCRIPTION
Before:
![Screen Shot 2021-12-12 at 11 06 42 PM](https://user-images.githubusercontent.com/17708295/145741509-bae1558b-d911-4d42-83dd-c95e84a5ed65.png)

After:
![Screen Shot 2021-12-12 at 11 05 38 PM](https://user-images.githubusercontent.com/17708295/145741439-8fa2b7e9-b917-4da9-a2c2-7b552232639a.png)


Includes two new buttons in the thread `Reply to thread` and `resolve` or `unresolved` a comment.