### PR TITLE
provide fallback query to github enterprise users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#127](https://github.com/wandersoncferreira/code-review/pull/127): introduce `code-review-github-graphql-host` variable
 - [#128](https://github.com/wandersoncferreira/code-review/pull/128): Gitlab support for URLs with subgroups
 - [#130](https://github.com/wandersoncferreira/code-review/pull/130): Mention user with `C-c @` in comment buffer.
+- [#131](https://github.com/wandersoncferreira/code-review/pull/131): Support Github Enterprise 3.0 by removing unsupported features in graphql schema
 
 # v0.0.4
 

--- a/code-review-gitlab.el
+++ b/code-review-gitlab.el
@@ -288,8 +288,8 @@ The payload is used to send a MR review to Gitlab."
       d))
     d))
 
-(cl-defmethod code-review-pullreq-infos ((gitlab code-review-gitlab-repo) callback)
-  "Get PR details from GITLAB and dispatch to CALLBACK."
+(cl-defmethod code-review-pullreq-infos ((gitlab code-review-gitlab-repo) fallback? callback)
+  "Get PR details from GITLAB, choose minimal query on FALLBACK? and dispatch to CALLBACK."
   (let* ((owner (oref gitlab owner))
          (repo (oref gitlab repo))
          (repo-clean (replace-regexp-in-string "%2F" "/" repo))
@@ -371,11 +371,13 @@ repository:project(fullPath: \"%s\") {
      nil
      callback)))
 
-(cl-defmethod code-review-infos-deferred ((gitlab code-review-gitlab-repo))
-  "Get PR infos from GITLAB."
+(cl-defmethod code-review-infos-deferred ((gitlab code-review-gitlab-repo) &optionally fallback?)
+  "Get PR infos from GITLAB.
+Optionally sets FALLBACK? to get minimal query."
   (let ((d (deferred:new #'identity)))
     (code-review-pullreq-infos
      gitlab
+     fallback?
      (apply-partially
       (lambda (d v &rest _)
         (deferred:callback-post d v))

--- a/code-review-interfaces.el
+++ b/code-review-interfaces.el
@@ -27,11 +27,11 @@
 ;;
 ;;; Code:
 
-(cl-defgeneric code-review-pullreq-infos (obj callback)
-  "Return infos Pull Request from a OBJ running CALLBACK with results.")
+(cl-defgeneric code-review-pullreq-infos (obj fallback? callback)
+  "Return infos Pull Request from a OBJ, use FALLBACK? to minimal query, run CALLBACK.")
 
-(cl-defgeneric code-review-infos-deferred (obj)
-  "Run OBJ with deferred.")
+(cl-defgeneric code-review-infos-deferred (obj fallback?)
+  "Run OBJ and set if minimal query should be run using FALLBACK?.")
 
 (cl-defgeneric code-review-pullreq-diff (obj callback)
   "Return diff for OBJ running CALLBACK with results.")


### PR DESCRIPTION
Attempt to fix #125.

I need another check on the graphql specs for enterprise 3.0 (older one) to verify if all the objects in the fallback query can be satisfied.