### PR TITLE
fix comment positioning for gitlab pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#143](https://github.com/wandersoncferreira/code-review/pull/143): add db migration scheme to introduce new columns in the future
 - [#148](https://github.com/wandersoncferreira/code-review/pull/148): fix UI heading bug #145.
 - [#150](https://github.com/wandersoncferreira/code-review/pull/150): fix broken indentation with Description heading
+- [#155](https://github.com/wandersoncferreira/code-review/pull/155): formal conversion between diff absolute position and diff line number.
 
 # v0.0.5
 

--- a/code-review-gitlab.el
+++ b/code-review-gitlab.el
@@ -28,10 +28,12 @@
 ;;
 ;;; Code:
 
+(require 'dash)
+(require 'let-alist)
 (require 'code-review-db)
+(require 'code-review-parse-hunk)
 (require 'code-review-interfaces)
 (require 'code-review-utils)
-(require 'let-alist)
 
 (defgroup code-review-gitlab nil
   "Interact with Gitlab REST and GraphQL APIs."

--- a/code-review-gitlab.el
+++ b/code-review-gitlab.el
@@ -127,7 +127,8 @@ an object then we need to build the diff string ourselves here."
   (let* ((review-comments (nreverse
                            (-filter
                             (lambda (c)
-                              (not (code-review-gitlab--regular-comment? c)))
+                              (and (not (code-review-gitlab--regular-comment? c))
+                                   (not (a-get c 'system))))
                             raw-comments)))
          (grouped-comments (-group-by
                             (lambda (c)
@@ -152,18 +153,16 @@ an object then we need to build the diff string ourselves here."
          (comment->code-review-comment
           (lambda (c)
             (let-alist c
-              (let* ((mapping  (alist-get .position.oldPath code-review-gitlab-line-diff-mapping
+              (let* ((path .position.oldPath)
+                     (mapping  (alist-get .position.oldPath code-review-gitlab-line-diff-mapping
                                           nil nil 'equal))
-                     (discussion-id (-second-item
-                                     (split-string .discussion.id "DiffDiscussion/")))
-                     (diff-pos
-                      ;; NOTE: not sure if this should not be a little different in the future
-                      ;; e.g. verify if the comment was done in Added/Removed/Unchanged line
-                      ;; and handling accordingly.
-                      (+ 1 (- (or .position.oldLine
-                                  .position.newLine)
-                              (or (a-get-in mapping (list 'old 'beg))
-                                  (a-get-in mapping (list 'new 'beg)))))))
+                     (line-obj (if .position.oldLine
+                                   `((old . t)
+                                     (line-pos . ,.position.oldLine))
+                                 `((new . t)
+                                   (line-pos . ,.position.newLine))))
+                     (discussion-id (-second-item (split-string .discussion.id "DiffDiscussion/")))
+                     (diff-pos (code-review-parse-hunk-relative-pos mapping line-obj)))
                 `((author (login . ,.author.login))
                   (state . ,"")
                   (bodyHTML .,"")
@@ -190,19 +189,9 @@ an object then we need to build the diff string ourselves here."
 (defun code-review-gitlab--regular-comment? (comment)
   "Predicate to identify regular (overview) COMMENT from review comment."
   (let-alist comment
-    (let ((has-in-mapping?
-           (or (a-get-in (alist-get .position.oldPath code-review-gitlab-line-diff-mapping
-                                    nil nil 'equal)
-                         (list 'old 'beg))
-               (a-get-in (alist-get .position.newPath code-review-gitlab-line-diff-mapping
-                                    nil nil 'equal)
-                         (list 'new 'beg)))))
-      (or (and (not .system)
-               (not has-in-mapping?))
-          (and (not .system)
-               (or (not (a-get comment 'resolvable))
-                   (not (a-get comment 'position))))
-          (not has-in-mapping?)))))
+    (and (not .system)
+         (or (not .resolvable)
+             (not .position)))))
 
 (defun code-review-gitlab-fix-infos (gitlab-infos)
   "Make GITLAB-INFOS structure compatible with GITHUB."
@@ -234,16 +223,19 @@ The payload is used to send a MR review to Gitlab."
          (pos (oref comment position)))
     (pcase line-type
       ("ADDED"
-       (a-assoc-in payload (list 'position 'new_line) pos))
+       (a-assoc-in payload (list 'position 'new_line)
+                   (code-review-parse-hunk-line-pos mapping `((added . t) (line-pos . ,pos)))))
       ("REMOVED"
        (a-assoc-in payload (list 'position 'old_line)
-                   (- (+ pos (a-get-in mapping (list 'old 'beg))) 1)))
+                   (code-review-parse-hunk-line-pos mapping `((deleted . t) (line-pos . ,pos)))))
       ("UNCHANGED"
-       (-> payload
-           (a-assoc-in (list 'position 'new_line)
-                       (+ (- pos (a-get-in mapping (list 'new 'end))) 1))
-           (a-assoc-in (list 'position 'old_line)
-                       (- (+ pos (a-get-in mapping (list 'old 'beg))) 1)))))))
+       (let ((line-pos-res
+              (code-review-parse-hunk-line-pos
+               mapping
+               `((normal . t) (line-pos . ,pos)))))
+         (-> payload
+             (a-assoc-in (list 'position 'new_line) (a-get line-pos-res 'new-line))
+             (a-assoc-in (list 'position 'old_line) (a-get line-pos-res 'old-line))))))))
 
 ;;; classes
 
@@ -385,36 +377,13 @@ Optionally sets FALLBACK? to get minimal query."
 
 (defun code-review-gitlab-pos-line-number->diff-line-number (gitlab-diff)
   "Get mapping of pos-line to diff-line given GITLAB-DIFF."
-  (let* ((if-zero-null (lambda (n)
-                         (let ((nn (string-to-number n)))
-                           (when (> nn 0)
-                             nn))))
-         (regex
-          (rx "@@ -"
-              (group-n 1 (one-or-more digit))
-              ","
-              (group-n 2 (one-or-more digit))
-              " +"
-              (group-n 3 (one-or-more digit))
-              ","
-              (group-n 4 (one-or-more digit))))
-         (res
+  (let* ((res
           (-reduce-from
            (lambda (acc it)
              (let ((str (a-get it 'diff)))
-               (save-match-data
-                 (if (and (string-match regex str))
-                     ;;; NOTE: it's possible that using "old_path" blindly here
-                     ;;; might cause issues when this value is null
-                     (a-assoc acc (or (a-get it 'old_path)
-                                      (a-get it 'new_path))
-                              (a-alist 'old (a-alist 'beg (funcall if-zero-null (match-string 1 str))
-                                                     'end (funcall if-zero-null (match-string 2 str))
-                                                     'path (a-get it 'old_path))
-                                       'new (a-alist 'beg (funcall if-zero-null (match-string 3 str))
-                                                     'end (funcall if-zero-null (match-string 4 str))
-                                                     'path (a-get it 'new_path))))
-                   acc))))
+               (a-assoc acc (or (a-get it 'old_path)
+                                (a-get it 'new_path))
+                        (code-review-parse-hunk-table str))))
            nil
            gitlab-diff)))
     (setq code-review-gitlab-line-diff-mapping res)))

--- a/code-review-parse-hunk.el
+++ b/code-review-parse-hunk.el
@@ -1,0 +1,159 @@
+;;; code-review-parse-hunk.el --- Library to parse hunk strings -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2021 Wanderson Ferreira
+;;
+;; Author: Wanderson Ferreira <https://github.com/wandersoncferreira>
+;; Maintainer: Wanderson Ferreira <wand@hey.com>
+;; Created: December 19, 2021
+;; Version: 0.0.5
+;;
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; For a full copy of the GNU General Public License
+;; see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;  Library to parse hunk strings
+;;
+;;; Code:
+
+(require 'dash)
+
+(defvar code-review-parse--hunk-regex
+  (rx "@@ -"
+      (group-n 1 (one-or-more digit))
+      ","
+      (group-n 2 (one-or-more digit))
+      " +"
+      (group-n 3 (one-or-more digit))
+      ","
+      (group-n 4 (one-or-more digit)))
+  "Regex to identify hunk sections.")
+
+(defun code-review-parse-hunk-table (hunkstring)
+  "Table with old line, new line, added/deleted line and relative pos from HUNKSTRING."
+  (let* ((difflines (split-string hunkstring "\n"))
+         (relative 0)
+         (del-counter 0)
+         (add-counter 0)
+         old-start
+         old-num-lines
+         new-start
+         new-num-lines
+         new-change
+         change
+         res)
+    (dolist (diffline difflines)
+      (cond
+       ((and (eq 0 relative)
+             (string-match code-review-parse--hunk-regex diffline))
+        (setq old-start (string-to-number (match-string 1 diffline))
+              old-num-lines (string-to-number (match-string 2 diffline))
+              new-start (string-to-number (match-string 3 diffline))
+              new-num-lines (string-to-number (match-string 4 diffline))
+              del-counter old-start
+              add-counter new-start
+              new-change nil))
+
+       ((and (string-match code-review-parse--hunk-regex diffline)
+             (not (eq 0 relative)))
+        (setq relative (+ 1 relative))
+        (setq old-start (string-to-number (match-string 1 diffline))
+              old-num-lines (string-to-number (match-string 2 diffline))
+              new-start (string-to-number (match-string 3 diffline))
+              new-num-lines (string-to-number (match-string 4 diffline))
+              del-counter old-start
+              add-counter new-start
+              new-change nil))
+
+       ((string-prefix-p "-" diffline)
+        (setq relative (+ 1 relative))
+        (setq change `((type . "del")
+                       (del . t)
+                       (ln . ,del-counter)
+                       (relative . ,relative))
+              old-num-lines (1- old-num-lines)
+              del-counter (1+ del-counter)
+              new-change t))
+
+       ((string-prefix-p "+" diffline)
+        (setq relative (+ 1 relative))
+        (setq change `((type . "add")
+                       (add . t)
+                       (ln . ,add-counter)
+                       (relative . ,relative))
+              new-num-lines (1- new-num-lines)
+              add-counter (1+ add-counter)
+              new-change t))
+
+       ((or (string-match-p "\s+" diffline)
+            (string-empty-p diffline))
+        (setq relative (+ 1 relative))
+        (setq change `((type . "normal")
+                       (normal . t)
+                       (ln1 . ,del-counter)
+                       (ln2 . ,add-counter)
+                       (relative . ,relative))
+              new-num-lines (1- new-num-lines)
+              add-counter (1+ add-counter)
+              del-counter (1+ del-counter)
+              new-change t)))
+      (when new-change
+        (if (not res)
+            (setq res (list change))
+          (setq res (append res (list change))))))
+    res))
+
+(defun code-review-parse-hunk-relative-pos (hunktable line-obj)
+  "Given a HUNKTABLE (`code-review-parse-hunk-table') and LINE-OBJ return absolute diff pos."
+  (let ((row
+         (let-alist line-obj
+           (if .old
+               (-filter
+                (lambda (it)
+                  (cond
+                   ((string-equal (a-get it 'type) "del")
+                    (>= (a-get it 'ln) .line-pos))
+                   ((string-equal (a-get it 'type) "normal")
+                    (>= (a-get it 'ln1) .line-pos))))
+                hunktable)
+             (-filter
+              (lambda (it)
+                (cond
+                 ((string-equal (a-get it 'type) "add")
+                  (>= (a-get it 'ln) .line-pos))
+                 ((string-equal (a-get it 'type) "normal")
+                  (>= (a-get it 'ln2) .line-pos))))
+              hunktable)))))
+    (a-get (-first-item row) 'relative)))
+
+(defun code-review-parse-hunk-line-pos (hunktable hunk-obj)
+  "Given a HUNKTABLE (`code-review-parse-hunk-table') and HUNK-OBJ return line pos."
+  (let-alist hunk-obj
+    (let ((row (-first-item
+                (-filter
+                 (lambda (it)
+                   (eq (a-get it 'relative) .line-pos))
+                 hunktable))))
+      (cond
+       (.added
+        (a-get row 'ln))
+       (.deleted
+        (a-get row 'ln))
+       (.normal
+        `((old-line . ,(a-get row 'ln1))
+          (new-line . ,(a-get row 'ln2))))))))
+
+(provide 'code-review-parse-hunk)
+;;; code-review-parse-hunk.el ends here

--- a/code-review-parse-hunk.el
+++ b/code-review-parse-hunk.el
@@ -26,6 +26,8 @@
 ;;
 ;;  Library to parse hunk strings
 ;;
+;;  https://stackoverflow.com/questions/41662127/how-to-comment-on-a-specific-line-number-on-a-pr-on-github
+;;
 ;;; Code:
 
 (require 'dash)

--- a/test/code-review-parse-hunk-test.el
+++ b/test/code-review-parse-hunk-test.el
@@ -1,0 +1,122 @@
+;;; code-review-parse-hunk-test.el --- Test parse diff functions
+;;; Commentary:
+;;; Code:
+;;;
+(require 'a)
+(require 'buttercup)
+(require 'code-review-parse-hunk)
+
+(defvar hunk-sample
+  "@@ -2,14 +2,7 @@
+
+ var hello = require('./hello.js');
+
+-var names = [
+-  'harry',
+-  'barry',
+-  'garry',
+-  'harry',
+-  'barry',
+-  'marry',
+-];
++var names = ['harry', 'barry', 'garry', 'harry', 'barry', 'marry'];
+
+ var names2 = [
+   'harry',
+@@ -23,9 +16,7 @@ var names2 = [
+ // after this line new chunk will be created
+ var names3 = [
+   'harry',
+-  'barry',
+-  'garry',
+   'harry',
+   'barry',
+-  'marry',
++  'marry', 'garry',
+ ];")
+
+(defvar expected-hunk-table
+  `(((type . "normal") (normal . t) (ln1 . 2) (ln2 . 2) (relative . 1))
+    ((type . "normal") (normal . t) (ln1 . 3) (ln2 . 3) (relative . 2))
+    ((type . "normal") (normal . t) (ln1 . 4) (ln2 . 4) (relative . 3))
+    ((type . "del") (del . t) (ln . 5) (relative . 4))
+    ((type . "del") (del . t) (ln . 6) (relative . 5))
+    ((type . "del") (del . t) (ln . 7) (relative . 6))
+    ((type . "del") (del . t) (ln . 8) (relative . 7))
+    ((type . "del") (del . t) (ln . 9) (relative . 8))
+    ((type . "del") (del . t) (ln . 10) (relative . 9))
+    ((type . "del") (del . t) (ln . 11) (relative . 10))
+    ((type . "del") (del . t) (ln . 12) (relative . 11))
+    ((type . "add") (add . t) (ln . 5) (relative . 12))
+    ((type . "normal") (normal . t) (ln1 . 13) (ln2 . 6) (relative . 13))
+    ((type . "normal") (normal . t) (ln1 . 14) (ln2 . 7) (relative . 14))
+    ((type . "normal") (normal . t) (ln1 . 15) (ln2 . 8) (relative . 15))
+    ((type . "normal") (normal . t) (ln1 . 23) (ln2 . 16) (relative . 17))
+    ((type . "normal") (normal . t) (ln1 . 24) (ln2 . 17) (relative . 18))
+    ((type . "normal") (normal . t) (ln1 . 25) (ln2 . 18) (relative . 19))
+    ((type . "del") (del . t) (ln . 26) (relative . 20))
+    ((type . "del") (del . t) (ln . 27) (relative . 21))
+    ((type . "normal") (normal . t) (ln1 . 28) (ln2 . 19) (relative . 22))
+    ((type . "normal") (normal . t) (ln1 . 29) (ln2 . 20) (relative . 23))
+    ((type . "del") (del . t) (ln . 30) (relative . 24))
+    ((type . "add") (add . t) (ln . 21) (relative . 25))
+    ((type . "normal") (normal . t) (ln1 . 31) (ln2 . 22) (relative . 26))))
+
+(describe "PARSE HUNK"
+  (it "Given a hunk, we return a table describing what happened with each hunk line."
+    (let ((table (code-review-parse-hunk-table hunk-sample)))
+      (expect table :to-equal expected-hunk-table))))
+
+(describe "RELATIVE POS"
+  :var (table)
+  (before-all
+    (setf table (code-review-parse-hunk-table hunk-sample)))
+  (it "Given a hunk parsed table we can ask for the relative position of a loc."
+    (let ((line-obj `((old . t)
+                      (line-pos . 23))))
+      (expect (code-review-parse-hunk-relative-pos table line-obj)
+              :to-equal 17)))
+  (it "Given a deleted line from the original file"
+    (let ((line-obj `((old . t)
+                      (line-pos . 6))))
+      (expect (code-review-parse-hunk-relative-pos table line-obj)
+              :to-equal 5)))
+  (it "Given yet another deleted line from the original file"
+    (let ((line-obj `((old . t)
+                      (line-pos . 30))))
+      (expect (code-review-parse-hunk-relative-pos table line-obj)
+              :to-equal 24)))
+  (it "Given a new line."
+    (let ((line-obj `((new . t)
+                      (line-pos . 5))))
+      (expect (code-review-parse-hunk-relative-pos table line-obj)
+              :to-equal 12)))
+  (it "Given yet another new line."
+    (let ((line-obj `((new . t)
+                      (line-pos . 21))))
+      (expect (code-review-parse-hunk-relative-pos table line-obj)
+              :to-equal 25))))
+
+(describe "DIFF POS"
+  :var (table)
+  :before-all
+  (setf table (code-review-parse-hunk-table hunk-sample))
+  (it "Given a relative line position in ADDED line, return the new line number."
+    (let ((hunk-obj `((added . t)
+                      (line-pos . 25))))
+      (expect (code-review-parse-hunk-line-pos table hunk-obj)
+              :to-equal 21)))
+  (it "Given a relative line position in DELETED line, return the new line number."
+    (let ((hunk-obj `((deleted . t)
+                      (line-pos . 21))))
+      (expect (code-review-parse-hunk-line-pos table hunk-obj)
+              :to-equal 27)))
+  (it "Given a relative line position in NORMAL line, return the new line number."
+    (let ((hunk-obj `((normal . t)
+                      (line-pos . 23))))
+      (expect (code-review-parse-hunk-line-pos table hunk-obj)
+              :to-equal `((old-line . 29)
+                          (new-line . 20))))))
+
+(provide 'code-review-parse-diff-test)
+;;; code-review-parse-diff-test.el ends here


### PR DESCRIPTION
Gitlab returns the Line number of a given comment and also expects a line number back. However, GitHub works with a `position` value as such:

> The position value is the number of lines down from the first "@@" hunk header in the file... The line just below the "@@" line is position 1, the next line is position 2, and so on. The position in the file's diff continues to increase through lines of whitespace and additional hunks until a new file is reached.


The current code has a hacky-incomplete way of translating between position and line numbers. Turns out that `position` is a lot better to handle in the emacs buffer (or maybe it is this way because I started the package supporting only this notion).

This PR has a dedicated file `code-review-parse-hunk.el` (and appropriate tests) to make this translation works in a reliable fashion.

This will also be used by the bitbucket cloud integration.