### PR TITLE
fix diff of files to be under files changed section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#155](https://github.com/wandersoncferreira/code-review/pull/155): formal conversion between diff absolute position and diff line number.
 - [#156](https://github.com/wandersoncferreira/code-review/pull/156): bitbucket cloud basic workflow integration
 - [#157](https://github.com/wandersoncferreira/code-review/pull/157): bitbucket stubs for not implemented feature.
+- [#159](https://github.com/wandersoncferreira/code-review/pull/159): place diff under Files Changed section
 
 # v0.0.5
 

--- a/code-review.el
+++ b/code-review.el
@@ -72,8 +72,7 @@
     code-review-section-insert-commits
     code-review-section-insert-pr-description
     code-review-section-insert-feedback-heading
-    code-review-section-insert-top-level-comments
-    code-review-section-insert-files-report)
+    code-review-section-insert-top-level-comments)
   "Hook run to insert sections into a code review buffer."
   :group 'code-review
   :type 'hook)


### PR DESCRIPTION
Related to #152

How files changed section behaves after this PR:

![output-2021-12-21-21:16:32](https://user-images.githubusercontent.com/17708295/147014001-7c2b8917-a4b0-48a7-89af-2549fd3ab39a.gif)

