### PR TITLE
Allow submitting a "COMMENT" review on Github with no feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#185](https://github.com/wandersoncferreira/code-review/pull/185): [gitlab] set title
 - [#187](https://github.com/wandersoncferreira/code-review/pull/187): [github] feature add - suggestion box bound to `C-c C-s`
 - [#188](https://github.com/wandersoncferreira/code-review/pull/188): commands to jump to comments forward and backwards 
+- [#189](https://github.com/wandersoncferreira/code-review/pull/190): Github: Ability to review a PR without leaving a feedback message
 
 # v0.0.6
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ Names below are sorted alphabetically.
 - Björn Larsson <develop@bjornlarsson.net>
 - Michael Eliachevitch <m.eliachevitch@posteo.de>
 - Ethan Leba <ethanleba5@gmail.com>
+- Kevin Fleming <kvnflm@gmail.com>
 
 # I would like to join this list. How can I help the project?
 

--- a/code-review-actions.el
+++ b/code-review-actions.el
@@ -95,7 +95,8 @@
   (and (not (oref review-obj feedback))
        (not (string-equal (oref review-obj state) "APPROVE"))
        (not (and (string-equal (oref review-obj state) "COMMENT")
-                 (code-review-gitlab-repo-p (oref review-obj pr))))))
+                 (or (code-review-github-repo-p (oref review-obj pr))
+                     (code-review-gitlab-repo-p (oref review-obj pr)))))))
 
 ;;;###autoload
 (defun code-review--submit (event &optional feedback only-reply?)


### PR DESCRIPTION
Fixes #189 