### PR TITLE
Clarify GitHub docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
 - [4ccad8c](https://github.com/wandersoncferreira/code-review/commit/4ccad8cb89ad38075a23023affbac1eb545a99ab): [gitlab] send feedback comment. Sorry commit on master, too tired :/
 - [#185](https://github.com/wandersoncferreira/code-review/pull/185): [gitlab] set title
 - [#187](https://github.com/wandersoncferreira/code-review/pull/187): [github] feature add - suggestion box bound to `C-c C-s`
-- [#188](https://github.com/wandersoncferreira/code-review/pull/188): commands to jump to comments forward and backwards 
+- [#188](https://github.com/wandersoncferreira/code-review/pull/188): commands to jump to comments forward and backwards
 - [#189](https://github.com/wandersoncferreira/code-review/pull/190): Github: Ability to review a PR without leaving a feedback message
+- [#198](https://github.com/wandersoncferreira/code-review/pull/198): [github] clarify docs
 
 # v0.0.6
 
@@ -71,7 +72,6 @@
 - [#86](https://github.com/wandersoncferreira/code-review/pull/86): allow users to define function to open Code Review buffer.
 - [#90](https://github.com/wandersoncferreira/code-review/pull/90): support visit binary files on Dired (`RET`) or Remote (`C-c C-v`)
 - [#93](https://github.com/wandersoncferreira/code-review/pull/93): add single top level comment in the PR page without a review attached
-
 
 # v0.0.2
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ Names below are sorted alphabetically.
 - Michael Eliachevitch <m.eliachevitch@posteo.de>
 - Ethan Leba <ethanleba5@gmail.com>
 - Kevin Fleming <kvnflm@gmail.com>
+- Luis Osa <luis.osa.gdc@gmail.com>
 
 # I would like to join this list. How can I help the project?
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -2,6 +2,8 @@
 
 ## Auth
 
+### Remote
+
 If you have trouble with the authinfo process below there is this nice
 [Tweet](https://twitter.com/iLemming/status/1463599279457673220) from @agzam
 explaining a bit the setup!
@@ -13,14 +15,39 @@ submitting reviews.
 2. Set the `repo` scope as the subscope of repo
 3. If using GitHub enterprise / for business you also need the `write:discussion` `read:discussion` scope.
 
-For enterprise users do not forget to change the value of
-`code-review-github-host` to match the host of your private instance. The
-current recommended way to use the package with enterprise solution is through
-`code-review-forge-pr-at-point` we have a bug identifying enterprise URLs in `code-review-start` yet.
+### Local
 
 Add a line to your auth source files, usually `~/.authinfo.gpg`, with your login
 and token:
 
 ```
-machine api.github.com login yourlogin^code-review password MYTOKENGOESHERE
+machine api.github.com login YOURLOGIN^code-review password YOURTOKENGOESHERE
+```
+
+If using a GitHub Enterprise instance, the URL for the `machine` needs to match the value of `code-review-github-host`. See below.
+
+```
+machine ghe.yourdomain.xyz/api login YOURLOGIN^code-review password YOURTOKENGOESHERE
+```
+
+## Configuration
+
+### GitHub Enterprise
+
+- Change the value of `code-review-github-host` to match the host of your private instance
+
+```
+(setq code-review-github-host "ghe.yourdomain.xyz/api")
+```
+
+- Change the value of `code-review-github-graphql-host`
+
+```
+(setq code-review-github-graphql-host "ghe.yourdomain.xyz/api")
+```
+
+- Optionally, set also the value of `code-review-github-base-url` to be able to start reviews with `code-review-start`, bypassing the Magit status buffer. If you ever only intend to start reviews from that buffer, you can skip this configuration.
+
+```
+(setq code-review-github-base-url "ghe.yourdomain.xyz")
 ```


### PR DESCRIPTION
Added more detail on the authentication, configuration and usage of `code-review` when used against a private GitHub enterprise instance. The information is taken from setting up the package myself, and also from [this issue](https://github.com/wandersoncferreira/code-review/issues/174) in the project's repository.

Mentions of a bug when using `code-review-start` are removed because the function does work in my setup, so the doc seems outdated in that respect.