### PR TITLE
Use API passwords configured for forge

### DIFF
--- a/code-review-bitbucket.el
+++ b/code-review-bitbucket.el
@@ -53,7 +53,7 @@ An optionally provide a CALLBACK."
   (ghub-request "POST" url
                 nil
                 :forge 'bitbucket
-                :auth 'code-review
+                :auth 'forge
                 :host code-review-bitbucket-host
                 :payload payload
                 :callback callback
@@ -64,7 +64,7 @@ An optionally provide a CALLBACK."
   (ghub-request "GET" url
                 nil
                 :forge 'bitbucket
-                :auth 'code-review
+                :auth 'forge
                 :host code-review-bitbucket-host
                 :callback callback))
 
@@ -73,7 +73,7 @@ An optionally provide a CALLBACK."
   (ghub-request "GET" url
                 nil
                 :forge 'bitbucket
-                :auth 'code-review
+                :auth 'forge
                 :host code-review-bitbucket-host
                 :noerror 'return))
 

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -85,7 +85,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
               nil
               :unpaginate t
               :headers code-review-github-diffheader
-              :auth 'code-review
+              :auth 'forge
               :host code-review-github-host
               :callback callback
               :errorback #'code-review-github-errback)))
@@ -110,7 +110,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
               nil
               :unpaginate t
               :headers code-review-github-diffheader
-              :auth 'code-review
+              :auth 'forge
               :host code-review-github-host
               :callback callback
               :errorback #'code-review-github-errback)))
@@ -497,7 +497,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
                   num)))
     (ghub-graphql query
                   nil
-                  :auth 'code-review
+                  :auth 'forge
                   :host code-review-github-graphql-host
                   :callback callback
                   :errorback #'code-review-github-errback)))
@@ -521,7 +521,7 @@ Optionally ask for the FALLBACK? query."
                            (oref github owner)
                            (oref github repo))
                    nil
-                   :auth 'code-review
+                   :auth 'forge
                    :host code-review-github-host
                    :noerror 'return)))
     (if (eq (car (-first-item resp)) 'message)
@@ -547,7 +547,7 @@ Optionally ask for the FALLBACK? query."
                                                    (a-get x 'name))
                                                  (oref github labels))
                                            []))
-             :auth 'code-review
+             :auth 'forge
              :host code-review-github-host
              :errorback #'code-review-github-errback
              :callback (lambda (&rest _) (funcall callback)))))
@@ -559,7 +559,7 @@ Optionally ask for the FALLBACK? query."
                            (oref github owner)
                            (oref github repo))
                    nil
-                   :auth 'code-review
+                   :auth 'forge
                    :host code-review-github-host
                    :noerror 'return)))
     (if (eq (car (-first-item resp)) 'message)
@@ -577,7 +577,7 @@ Optionally ask for the FALLBACK? query."
                      (oref github repo)
                      (oref github number))
              nil
-             :auth 'code-review
+             :auth 'forge
              :host code-review-github-host
              :payload (a-alist 'assignees (-map (lambda (it)
                                                   (a-get it 'login))
@@ -592,7 +592,7 @@ Optionally ask for the FALLBACK? query."
                            (oref github owner)
                            (oref github repo))
                    nil
-                   :auth 'code-review
+                   :auth 'forge
                    :host code-review-github-host
                    :noerror 'return)))
     (if (eq (car (-first-item resp)) 'message)
@@ -610,7 +610,7 @@ Optionally ask for the FALLBACK? query."
                       (oref github repo)
                       (oref github number))
               nil
-              :auth 'code-review
+              :auth 'forge
               :host code-review-github-host
               :payload (a-alist 'milestone (a-get (oref github milestones) 'number))
               :errorback #'code-review-github-errback
@@ -627,7 +627,7 @@ Optionally ask for the FALLBACK? query."
                       (oref github repo)
                       (oref github number))
               nil
-              :auth 'code-review
+              :auth 'forge
               :host code-review-github-host
               :payload (a-alist 'title (oref github title))
               :errorback #'code-review-github-errback
@@ -641,7 +641,7 @@ Optionally ask for the FALLBACK? query."
                       (oref github repo)
                       (oref github number))
               nil
-              :auth 'code-review
+              :auth 'forge
               :host code-review-github-host
               :payload (a-alist 'body (a-get (oref github raw-infos) 'bodyText))
               :errorback #'code-review-github-errback
@@ -654,7 +654,7 @@ Optionally ask for the FALLBACK? query."
                     (oref github repo)
                     (oref github number))
             nil
-            :auth 'code-review
+            :auth 'forge
             :host code-review-github-host
             :payload (a-alist 'commit_title (oref github title)
                               'commit_message (oref github description)
@@ -683,7 +683,7 @@ Optionally ask for the FALLBACK? query."
                        (oref github repo)
                        path)
                nil
-               :auth 'code-review
+               :auth 'forge
                :host code-review-github-host
                :payload (a-alist 'content r))))
 
@@ -701,7 +701,7 @@ Optionally ask for the FALLBACK? query."
                          (oref github repo)
                          path)
                  nil
-                 :auth 'code-review
+                 :auth 'forge
                  :host code-review-github-host)))
 
 (defclass code-review-submit-github-replies ()
@@ -727,7 +727,7 @@ Optionally ask for the FALLBACK? query."
                         nil
                         :payload (a-alist 'body (oref reply body))
                         :headers code-review-github-diffheader
-                        :auth 'code-review
+                        :auth 'forge
                         :host code-review-github-host
                         :callback (lambda (&rest _))
                         :errorback #'code-review-github-errback)))
@@ -774,7 +774,7 @@ Optionally ask for the FALLBACK? query."
                        (oref pr repo)
                        (oref pr number))
                nil
-               :auth 'code-review
+               :auth 'forge
                :payload payload
                :host code-review-github-host
                :errorback #'code-review-github-errback
@@ -807,7 +807,7 @@ Optionally ask for the FALLBACK? query."
                                            `((repo_owner . ,(oref github owner))
                                              (repo_name . ,(oref github repo))
                                              (cursor . ,cursor))
-                                           :auth 'code-review
+                                           :auth 'forge
                                            :host code-review-github-graphql-host)))
             (let-alist graphql-res
               (setq has-next-page .data.repository.assignableUsers.pageInfo.hasNextPage
@@ -831,7 +831,7 @@ Optionally ask for the FALLBACK? query."
     (ghub-graphql query
                   `((input . ((pullRequestId . ,pr-id)
                               (userIds . ,user-ids))))
-                  :auth 'code-review
+                  :auth 'forge
                   :host code-review-github-graphql-host
                   :callback (lambda (&rest _)
                               (message "Review requested successfully!")
@@ -844,7 +844,7 @@ Optionally ask for the FALLBACK? query."
                      (oref github owner)
                      (oref github repo))
              nil
-             :auth 'code-review
+             :auth 'forge
              :host code-review-github-host
              :payload (a-alist 'body body 'title title)
              :errorback #'code-review-github-errback
@@ -906,7 +906,7 @@ Return the blob URL if BLOB? is provided."
                      (oref github repo)
                      (oref github number))
              nil
-             :auth 'code-review
+             :auth 'forge
              :host code-review-github-host
              :payload (a-alist 'body comment-msg)
              :callback callback
@@ -919,7 +919,7 @@ Return the blob URL if BLOB? is provided."
                      (oref github repo)
                      (oref github number))
              nil
-             :auth 'code-review
+             :auth 'forge
              :headers '(("Accept" . "application/vnd.github.v3+json"))
              :host code-review-github-host
              :payload (a-alist 'path (oref local-comment path)

--- a/code-review-gitlab.el
+++ b/code-review-gitlab.el
@@ -78,7 +78,7 @@ Optionally using VARIABLES.  Provide HOST and CALLBACK fn."
   (glab-request "POST" "/graphql" nil :payload (json-encode
                                                 `(("query" . ,graphql)
                                                   ,@(and variables `(("variables" ,@variables)))))
-                :auth 'code-review
+                :auth 'forge
                 :host code-review-gitlab-graphql-host
                 :callback callback
                 :errorback #'code-review-gitlab-errback))
@@ -284,7 +284,7 @@ The payload is used to send a MR review to Gitlab."
             nil
             :unpaginate t
             :host code-review-gitlab-host
-            :auth 'code-review
+            :auth 'forge
             :callback callback
             :errorback #'code-review-gitlab-errback))
 
@@ -426,7 +426,7 @@ Optionally sets FALLBACK? to get minimal query."
                                 (oref reply reply-to-id))
                         nil
                         :payload (a-alist 'body (oref reply body))
-                        :auth 'code-review
+                        :auth 'forge
                         :host code-review-gitlab-host
                         :errorback #'code-review-gitlab-errback
                         :callback (lambda (&rest _)))))
@@ -467,7 +467,7 @@ Optionally sets FALLBACK? to get minimal query."
                            (code-review-gitlab--project-id pr)
                            (oref pr number))
                    nil
-                   :auth 'code-review
+                   :auth 'forge
                    :host code-review-gitlab-host
                    :payload (code-review-gitlab-fix-payload payload c)
                    :callback (lambda (&rest _)
@@ -479,7 +479,7 @@ Optionally sets FALLBACK? to get minimal query."
                           (code-review-gitlab--project-id pr)
                           (oref pr number))
                   nil
-                  :auth 'code-review
+                  :auth 'forge
                   :host code-review-gitlab-host
                   :payload `((sha . ,(a-get-in infos (list 'diffRefs 'headSha))))
                   :username (code-review-gitlab--user)))
@@ -490,7 +490,7 @@ Optionally sets FALLBACK? to get minimal query."
                           (code-review-gitlab--project-id pr)
                           (oref pr number))
                   nil
-                  :auth 'code-review
+                  :auth 'forge
                   :host code-review-gitlab-host
                   :payload `((body . ,(oref review feedback))))
        (message "Review Comment successfully sent!")))
@@ -518,7 +518,7 @@ Optionally sets FALLBACK? to get minimal query."
                        nil
                        :unpaginate t
                        :host code-review-gitlab-host
-                       :auth 'code-review
+                       :auth 'forge
                        :noerror 'return)))
     (if (a-get res 'error)
         (error (prin1-to-string res))
@@ -535,7 +535,7 @@ Optionally sets FALLBACK? to get minimal query."
                       (code-review-gitlab--project-id gitlab)
                       (oref gitlab number))
               nil
-              :auth 'code-review
+              :auth 'forge
               :host code-review-gitlab-host
               :payload `((labels .,labels-str))
               :callback (lambda (&rest _) (funcall callback)))))
@@ -562,7 +562,7 @@ Optionally sets FALLBACK? to get minimal query."
                     (code-review-gitlab--project-id gitlab)
                     (oref gitlab number))
             nil
-            :auth 'code-review
+            :auth 'forge
             :host code-review-gitlab-host
             :payload `((title .,(oref gitlab title)))
             :callback (lambda (&rest _) (funcall callback))))
@@ -608,7 +608,7 @@ Return the blob URL if BLOB? is provided."
                      (code-review-gitlab--project-id gitlab)
                      (oref gitlab number))
              nil
-             :auth 'code-review
+             :auth 'forge
              :host code-review-gitlab-host
              :payload (a-alist 'body comment-msg)
              :callback callback
@@ -628,7 +628,7 @@ Return the blob URL if BLOB? is provided."
                        (code-review-gitlab--project-id gitlab)
                        (oref gitlab number))
                nil
-               :auth 'code-review
+               :auth 'forge
                :host code-review-gitlab-host
                :payload (code-review-gitlab-fix-payload payload local-comment)
                :callback (lambda (&rest _)


### PR DESCRIPTION
code-review searches for authentication data in ~/.authinfo.gpg by looking
for logins ending with "^code-review", similar to how magit forge looks
for logins ending with "^forge". Since code-review depends on forge and many
users may already have configured magit forge, use the forge passwords. This
way, the user does not have to add more lines to the authinfo.gpg file.

This fixes issue #211.