### PR TITLE
Fix suggestion code block

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ Names below are sorted alphabetically.
 - Ron Lusk <ronlusk@gmail.com>
 - Brian Leung <leungbk@posteo.net>
 - Harald Judt <h.judt@gmx.at>
+- [@RagnarGrootKoerkamp](https://github.com/RagnarGrootKoerkamp)
 
 # I would like to join this list. How can I help the project?
 

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -206,7 +206,7 @@ Optionally define a MSG."
                          (t
                           "UNCHANGED")))
              (suggestion
-              (format "%s\n\n```suggestion\n %s\n"
+              (format "%s\n\n```suggestion\n%s\n```\n"
                       code-review-comment-suggestion-msg
                       (substring line 1)))
              (amount-loc nil))


### PR DESCRIPTION
Before, creating a suggestion would make a single row of three backticks, followed by a newline with a space and then the previous string.
While it seems the closing backticks are not needed for GitHub to parse this correctly, adding them seems cleaner.
The extra space seems unneeded here.

(Note: I didn't test this.)