### PR TITLE
General fixes - section hide inconsistencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - 25.1
           - 26.1
           - 27.1
         ignore_warnings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+- [#218](https://github.com/wandersoncferreira/code-review/pull/218): fix section toggle on files changed, small UI issues, fix CI, organize code
+- [#217](https://github.com/wandersoncferreira/code-review/pull/217): fix suggestion code block
+- [#213](https://github.com/wandersoncferreira/code-review/pull/213): Make auth login marker configurable
+
 # v0.0.7
 
 - [#169](https://github.com/wandersoncferreira/code-review/pull/169): [gitlab] set labels command
@@ -19,7 +23,6 @@
 - [#198](https://github.com/wandersoncferreira/code-review/pull/198): [github] clarify docs
 - [a7e3d7b](https://github.com/luskwater/code-review/commit/a7e3d7b39d6e442690295767944cb7e42b7a3757): fix minor typo in prompt for unfinished reviews
 - [#199](https://github.com/wandersoncferreira/code-review/pull/199): [github] clarify configuration for *GitHub Enterprise*
-- [#213](https://github.com/wandersoncferreira/code-review/pull/213): Make auth login marker configurable
 
 # v0.0.6
 

--- a/Cask
+++ b/Cask
@@ -4,6 +4,7 @@
 (depends-on "emacs" "25.1")
 (depends-on "closql" "1.2.0")
 (depends-on "magit" "3.0.0")
+(depends-on "transient" "0.3.7")
 (depends-on "a" "1.0.0")
 (depends-on "ghub" "3.5.1")
 (depends-on "uuidgen" "1.2")

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ Use passwords configured for forge. The default is `'code-review`.
 (setq code-review-auth-login-marker 'forge)
 ```
 
+#### Doom Emacs users
+
+I've noticed that `*Code Review*` buffer is not added into the current workspace
+in Doom emacs. If you have `workspaces` in your `$DOOMDIR/init.el` file,
+consider the following snippet:
+
+``` emacs-lisp
+(add-hook 'code-review-mode-hook
+          (lambda ()
+            ;; include *Code-Review* buffer into current workspace
+            (persp-add-buffer (current-buffer))))
+```
+
 
 ### Forge specific
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ code-review-forge-pr-at-point` if you are in a forge buffer over a PR.
 
 ### Code Review
 
+If you want to see pretty symbols enable `emojify` package:
+
+``` emacs-lisp
+(add-hook 'code-review-mode-hook #'emojify-mode)
+```
+
 Define line wrap in comment sections.
 
 ``` emacs-lisp

--- a/code-review-db.el
+++ b/code-review-db.el
@@ -540,7 +540,7 @@ Very Bad Performance!."
        (let* ((comments (oref path comments))
               (comment (if (eieio-object-p comments) comments (-first-item comments))))
          (if written?
-             written?
+             t
            (when comment
              (-contains-p (oref comment identifiers) identifier)))))
      nil

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -591,8 +591,7 @@ INDENT count of spaces are added at the start of every line."
                          (when .at
                            (insert " " (propertize (code-review-utils--format-timestamp .at) 'face 'code-review-timestamp-face))))
                        (insert ?\n)))))
-               groups)
-      (insert ?\n))))
+               groups))))
 
 ;; headers hook definition
 
@@ -804,6 +803,10 @@ INDENT count of spaces are added at the start of every line."
                                  (--sort
                                   (< (time-to-seconds (date-to-time (a-get it 'createdAt)))
                                      (time-to-seconds (date-to-time (a-get other 'createdAt))))))))
+      (when (not list-of-comments)
+        (insert (propertize "No conversation found." 'font-lock-face 'magit-dimmed))
+        (insert ?\n))
+
       (dolist (c list-of-comments)
         (let* ((reactions (a-get-in c (list 'reactions 'nodes)))
                (reaction-objs (when reactions
@@ -832,7 +835,8 @@ INDENT count of spaces are added at the start of every line."
                reaction-objs
                "comment"
                (a-get c 'databaseId)))
-            (insert ?\n)))))))
+            (insert ?\n))))
+      (insert ?\n))))
 
 (cl-defmethod code-review--insert-conversation-section ((gitlab code-review-gitlab-repo))
   "Function to insert conversation section for GITLAB PRs."
@@ -1430,6 +1434,20 @@ A quite good assumption: every comment in an outdated hunk will be outdated."
                    amount-loc-incr))
             (code-review-comment-insert-lines c)))))))
 
+(defun code-review-section-insert-files-changed ()
+  (let ((files (a-get (code-review-db--pullreq-raw-infos) 'files)))
+    (let-alist files
+      (insert (propertize
+               (concat "Files changed"
+                       (when files
+                         (format " (%s files; %s additions, %s deletions)"
+                                 (length .nodes)
+                                 (apply #'+ (mapcar (lambda (x) (alist-get 'additions x)) .nodes))
+                                 (apply #'+ (mapcar (lambda (x) (alist-get 'deletions x)) .nodes)))))
+               'font-lock-face
+               'magit-section-heading)))
+    (magit-insert-heading)))
+
 (defun code-review-section--magit-diff-insert-file-section
     (file orig status modes rename header &optional long-status)
   "Overwrite the original Magit function on `magit-diff.el' FILE.
@@ -1444,7 +1462,7 @@ ORIG, STATUS, MODES, RENAME, HEADER and LONG-STATUS are arguments of the origina
                        raw-path-name)))
     (code-review-db--curr-path-update clean-path))
     ;;; --- end -- code-review specific code.
-
+  (insert ?\n)
   (magit-insert-section section
     (file file (or (equal status "deleted")
                    (derived-mode-p 'magit-status-mode)))
@@ -1473,7 +1491,8 @@ ORIG, STATUS, MODES, RENAME, HEADER and LONG-STATUS are arguments of the origina
                             'face 'code-review-request-review-face
                             'mouse-face 'highlight
                             'help-echo "Visit the file in Dired buffer"
-                            'keymap 'code-review-binary-file-section-map) "\n")))
+                            'keymap 'code-review-binary-file-section-map))
+        (magit-insert-heading)))
     (magit-wash-sequence #'magit-diff-wash-hunk)))
 
 (defun code-review-section--magit-diff-wash-hunk ()
@@ -1489,7 +1508,7 @@ Argument GROUPED-COMMENTS comments grouped by path and diff position."
            (path-name (oref path name))
            (head-pos (oref path head-pos)))
       (when (not head-pos)
-        (let ((adjusted-pos (+ 1 (code-review--line-number-at-pos))))
+        (let ((adjusted-pos (+ (code-review--line-number-at-pos) 1)))
           (code-review-db--curr-path-head-pos-update path-name adjusted-pos)
           (setq head-pos adjusted-pos)
           (setq path-name path-name)))
@@ -1570,6 +1589,9 @@ Please Report this Bug" path-name))
 
 ;;; * build buffer
 
+(defclass code-review--root-section (magit-section)
+  ((body :initform nil)))
+
 (defun code-review--trigger-hooks (buff-name &optional commit-focus? msg)
   "Trigger magit section hooks and draw BUFF-NAME.
 Run code review commit buffer hook when COMMIT-FOCUS? is non-nil.
@@ -1594,24 +1616,12 @@ If you want to display a minibuffer MSG in the end."
               (erase-buffer)
               (insert (code-review-db--pullreq-raw-diff))
               (insert ?\n))
-            (magit-insert-section (review-buffer)
+            (magit-insert-section section (code-review--root-section)
               (magit-insert-section (code-review)
-                (if commit-focus?
-                    (magit-run-section-hook 'code-review-sections-commit-hook)
-                  (magit-run-section-hook 'code-review-sections-hook)))
-              (let ((files (a-get (code-review-db--pullreq-raw-infos) 'files)))
-                (magit-insert-section (code-review-files-report-section)
-                  (let-alist files
-                    (insert (propertize
-                             (concat "Files changed"
-                                     (when files
-                                       (format " (%s files; %s additions, %s deletions)"
-                                               (length .nodes)
-                                               (apply #'+ (mapcar (lambda (x) (alist-get 'additions x)) .nodes))
-                                               (apply #'+ (mapcar (lambda (x) (alist-get 'deletions x)) .nodes)))))
-                             'font-lock-face
-                             'magit-section-heading)))
-                  (magit-insert-heading)
+                (magit-run-section-hook 'code-review-sections-hook))
+              (magit-insert-section (code-review-files-report-section)
+                (code-review-section-insert-files-changed)
+                (magit-insert-section (code-review-files-chnged)
                   (magit-wash-sequence
                    (apply-partially #'magit-diff-wash-diff ())))))
             (if window

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -646,7 +646,7 @@ INDENT count of spaces are added at the start of every line."
                     (progn
                       (insert (format "%s%s %s "
                                       (propertize (format "%-6s " (oref obj sha)) 'font-lock-face 'magit-hash)
-                                      (oref obj msg)
+                                      (car (split-string (oref obj msg) "\n"))
                                       (if (string-equal .commit.statusCheckRollup.state "SUCCESS")
                                           ":white_check_mark:"
                                         ":x:")))

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -654,6 +654,9 @@ INDENT count of spaces are added at the start of every line."
                        (propertize "Expand for Details:" 'font-lock-face 'code-review-checker-detail-face))
                       (oset commit-section hidden t)
                       (magit-insert-heading)
+                      (when (> (length (split-string (oref obj msg) "\n")) 1)
+                        (insert (oref obj msg))
+                        (insert "\n"))
                       (dolist (check .commit.statusCheckRollup.contexts.nodes)
                         (let-alist check
                           (let ((obj (code-review-commit-check-detail-section :check check :details .detailsUrl)))

--- a/code-review.el
+++ b/code-review.el
@@ -8,7 +8,7 @@
 ;; Version: 0.0.7
 ;; Keywords: git, tools, vc
 ;; Homepage: https://github.com/wandersoncferreira/code-review
-;; Package-Requires: ((emacs "25.1") (closql "1.2.0") (magit "3.0.0") (a "1.0.0") (ghub "3.5.1") (uuidgen "1.2") (deferred "0.5.1") (markdown-mode "2.4") (forge "0.3.0") (emojify "1.2"))
+;; Package-Requires: ((emacs "25.1") (closql "1.2.0") (magit "3.0.0") (transient "0.3.7") (a "1.0.0") (ghub "3.5.1") (uuidgen "1.2") (deferred "0.5.1") (markdown-mode "2.4") (forge "0.3.0") (emojify "1.2"))
 
 ;; This file is not part of GNU Emacs
 


### PR DESCRIPTION
Fixes performed:

- [x] Conversation section without any default value
- [x] Refactor function to include binary files to its own `defun`
- [x] Break the commit msg to include a single line in the PR page and show the whole body once the commit is toggled
- [x] Improve docs for Doom Emacs users on `workspaces` and `emojify`
- [x] Create a proper `magit-section-root` to the root node in the review buffer
- [x] Fix inconsistencies with `magit-section-toggle` on `Files changed` section
  - The solution here is not good yet, I've managed to find some issues with the region used by `magit-section` but couldn't find why this happens as all of this code is delegated to `magit-diff-wash-diff` function. Anyway, I added an extra space between each file name and I was not able to reproduce the error anymore. Aesthetically not pleasant, but I'm more concerned with keeping the functionality predictable and stable now.
- [ ] Fix comments mis-positioning once send to remote
  - I'll need more time to investigate this one. I was able to reproduce the issue following the descriptions https://github.com/wandersoncferreira/code-review/issues/216
- [x] Fix CI
- [ ] Check if would be possible to improve Emacs Evil experience in the buffer