### PR TITLE
feat: add file viewed state tracking with GitHub sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ tmp/
 
 *.elc
 .cask
+
+# pi-crew
+.crew/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ tmp/
 
 # pi-crew
 .crew/
+
+/.crew/
+/.crew
+!.crew/artifacts/
+!.crew/graphs/
+!.crew/artifacts/.gitkeep
+!.crew/graphs/.gitkeep

--- a/.pi/agents/supervisor.md
+++ b/.pi/agents/supervisor.md
@@ -1,0 +1,33 @@
+---
+name: supervisor
+# tools: read,write,edit,bash,grep,find,ls
+# model:
+# standalone: true
+---
+
+<!-- ═══════════════════════════════════════════════════════════════════
+  Project-Specific Supervisor Guidance
+
+  This file is COMPOSED with the base supervisor prompt shipped in the
+  taskplane package. Your content here is appended after the base prompt.
+
+  The base prompt (maintained by taskplane) handles:
+  - Supervisor identity and standing orders
+  - Recovery action classification and autonomy levels
+  - Audit trail format and rules
+  - Batch monitoring, failure handling, operator communication
+  - Orchestrator tool reference (orch_status, orch_pause, etc.)
+  - Startup checklist and operational knowledge
+
+  Add project-specific supervisor rules below. Common examples:
+  - Run linter before integration ("always run `npm run lint` after merge")
+  - CI dashboard URL for failure triage
+  - PR template or label conventions
+  - Project-specific recovery procedures
+  - Team notification preferences (Slack, etc.)
+  - Custom health check commands
+
+  To override frontmatter values (tools, model), uncomment and edit above.
+  To use this file as a FULLY STANDALONE prompt (ignoring the base),
+  uncomment `standalone: true` above and write the complete prompt below.
+═══════════════════════════════════════════════════════════════════ -->

--- a/.pi/taskplane.json
+++ b/.pi/taskplane.json
@@ -1,0 +1,9 @@
+{
+  "migrations": {
+    "applied": {
+      "add-supervisor-local-template-v1": {
+        "appliedAt": "2026-06-01T06:45:40.994Z"
+      }
+    }
+  }
+}

--- a/code-review-actions.el
+++ b/code-review-actions.el
@@ -768,5 +768,49 @@ If a valid ASSIGNEE is provided, use that instead."
 
 (code-review-set-obsolete-fns)
 
+;;;
+;;;; * Toggle file viewed state
+;;;
+
+;; declared in code-review-section.el
+(declare-function code-review--add-viewed-overlay "code-review-section" (path))
+(declare-function code-review--remove-viewed-overlay "code-review-section" (path))
+(declare-function code-review--viewed-overlay-for "code-review-section" (path))
+
+;;;###autoload
+(defun code-review-toggle-file-viewed ()
+  "Toggle viewed state for the file at point in the current PR.
+
+Sends markFileAsViewed / unmarkFileAsViewed to GitHub and updates
+local indicator immediately so you can track review progress.
+
+Files marked as viewed are fetched from GitHub each time the
+Code Review buffer is built."
+  (interactive)
+  (let ((path (code-review-utils--file-path-at-point))
+        (pr (code-review-db-get-pullreq))
+        (buffer (current-buffer)))
+    (unless path
+      (user-error "Not on a file section"))
+    (unless (code-review-github-repo-p pr)
+      (user-error "File viewed state is only supported for GitHub PRs"))
+
+    (let* ((existing (code-review--viewed-overlay-for path))
+           (viewed (not (not existing)))
+           (new-state (not viewed)))
+      (if new-state
+          (code-review--add-viewed-overlay path)
+        (code-review--remove-viewed-overlay path))
+
+      (message "%s %s..." (if new-state "Marking" "Unmarking") path)
+      (let ((fn (if new-state #'code-review-mark-file-viewed
+                  #'code-review-unmark-file-viewed)))
+        (funcall fn pr path
+                 (lambda ()
+                   (when (buffer-live-p buffer)
+                     (with-current-buffer buffer
+                       (message "%s %s on GitHub ✓"
+                                (if new-state "Viewed" "Unviewed") path)))))))))
+
 (provide 'code-review-actions)
 ;;; code-review-actions.el ends here

--- a/code-review-actions.el
+++ b/code-review-actions.el
@@ -801,6 +801,7 @@ Code Review buffer is built."
       (if new-state
           (code-review--add-viewed-overlay path)
         (code-review--remove-viewed-overlay path))
+      (code-review-section--update-viewed-counter)
 
       (message "%s %s..." (if new-state "Marking" "Unmarking") path)
       (let ((fn (if new-state #'code-review-mark-file-viewed

--- a/code-review-actions.el
+++ b/code-review-actions.el
@@ -55,13 +55,15 @@
 ;;;
 
 (defclass code-review-submit-local-coment ()
-  ((path     :initarg :path)
-   (position :initarg :position)
-   (line     :initarg :line
-             :initform nil)
-   (body     :initarg :body)
+  ((path      :initarg :path)
+   (position  :initarg :position)
+   (line      :initarg :line
+              :initform nil)
+   (end-line  :initarg :end-line
+              :initform nil)
+   (body      :initarg :body)
    (internal-id :initarg :internal-id)
-   (line-type :initarg :line-type)))
+   (line-type  :initarg :line-type)))
 
 (defclass code-review-submit-review ()
   ((state :initform nil)
@@ -161,6 +163,7 @@ If you want only to submit replies, use ONLY-REPLY? as non-nil."
                             :path (oref value path)
                             :position (oref value position)
                             :line (oref value line)
+                            :end-line (oref value end-line)
                             :body (oref value msg)
                             :internal-id (oref value internalId)
                             :line-type (oref value line-type))

--- a/code-review-actions.el
+++ b/code-review-actions.el
@@ -57,6 +57,8 @@
 (defclass code-review-submit-local-coment ()
   ((path     :initarg :path)
    (position :initarg :position)
+   (line     :initarg :line
+             :initform nil)
    (body     :initarg :body)
    (internal-id :initarg :internal-id)
    (line-type :initarg :line-type)))
@@ -158,6 +160,7 @@ If you want only to submit replies, use ONLY-REPLY? as non-nil."
                      (push (code-review-submit-local-coment
                             :path (oref value path)
                             :position (oref value position)
+                            :line (oref value line)
                             :body (oref value msg)
                             :internal-id (oref value internalId)
                             :line-type (oref value line-type))

--- a/code-review-actions.el
+++ b/code-review-actions.el
@@ -104,6 +104,7 @@
 If you already have a FEEDBACK string use it.
 If you want only to submit replies, use ONLY-REPLY? as non-nil."
   (interactive)
+  (message "[code-review] --submit event=%S feedback=%S only-reply?=%S" event feedback only-reply?)
   (setq code-review-comment-cursor-pos (point))
   (let* ((pr (code-review-db-get-pullreq))
          (review-obj (cond
@@ -165,6 +166,8 @@ If you want only to submit replies, use ONLY-REPLY? as non-nil."
 
       (oset replies-obj replies replies)
       (oset review-obj local-comments local-comments)
+      (message "[code-review] scan found %d replies, %d local-comments"
+               (length replies) (length local-comments))
 
       (if (and (code-review--submit-feedback-required? review-obj)
                (not only-reply?))

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -216,7 +216,7 @@ Optionally define a MSG."
                               (save-excursion
                                 (goto-char region-start)
                                 (string-join
-                                 (-map (lambda (l) (substring l (if (string-prefix-p " " l) 1 0)))
+                                 (-map (lambda (l) (substring l 1))
                                        (split-string
                                         (buffer-substring-no-properties
                                          (save-excursion

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -245,8 +245,9 @@ Optionally define a MSG."
                                                (a-get obj 'head-pos)))))
                                 (and (> e diff-pos) e))))
                ;; Convert diff-relative positions to file line numbers
-               ;; hunk value = (about . ranges) where ranges = ((base?) (from) (to))
-               (to-start (car (car (last (cdr obj)))))
+               ;; section value = (value . (hunk-value . ranges) path . ... head-pos . N)
+               (to-start (let ((hunk-val (a-get obj 'value)))
+                           (car (car (last (cdr hunk-val))))))
                (file-line (+ to-start diff-pos -1))
                (file-end  (and diff-end (+ to-start diff-end -1)))
                (local-comment (code-review-local-comment-section

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -313,6 +313,7 @@ Inform if a SUGGESTION-CODE? is being proposed."
                                           (bodyText . ,clean-msg)
                                           (path . ,(oref obj path))
                                           (position . ,(oref obj position))
+                                          (line . ,(oref obj line))
                                           (databaseId)
                                           (diffHunk)
                                           (outdated)

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -195,8 +195,11 @@ Optionally define a MSG."
         (message "You can't add text over unspecified region.")
       (let* ((region-start (and (region-active-p) (region-beginning)))
              (region-end   (and (region-active-p) (region-end)))
-             (current-line (line-number-at-pos))
+             ;; Use region lines when available, else current line
+             (first-line (line-number-at-pos (or region-start (point))))
+             (last-line  (line-number-at-pos (or region-end (point))))
              (line (save-excursion
+                     (when region-start (goto-char region-start))
                      (buffer-substring-no-properties
                       (line-beginning-position)
                       (line-end-position))))
@@ -207,10 +210,25 @@ Optionally define a MSG."
                           "ADDED")
                          (t
                           "UNCHANGED")))
+             ;; Build suggestion from region text, stripping +/- prefix
              (suggestion
-              (format "%s\n\n```suggestion\n%s\n```\n"
-                      code-review-comment-suggestion-msg
-                      (substring line 1)))
+              (let ((code (if region-start
+                              (save-excursion
+                                (goto-char region-start)
+                                (string-join
+                                 (-map (lambda (l) (substring l (if (string-prefix-p " " l) 1 0)))
+                                       (split-string
+                                        (buffer-substring-no-properties
+                                         (save-excursion
+                                           (goto-char region-start)
+                                           (line-beginning-position))
+                                         (save-excursion
+                                           (goto-char region-end)
+                                           (line-end-position)))
+                                        "\n")))
+                            (substring line 1))))
+                (format "%s\n\n```suggestion\n%s\n```\n"
+                        code-review-comment-suggestion-msg code)))
              (amount-loc nil))
         (save-excursion
           (while (and (not (looking-at
@@ -225,11 +243,11 @@ Optionally define a MSG."
                     (setq amount-loc 0)
                   (setq amount-loc (or (oref value amount-loc) 0)))))))
 
-        (let* ((diff-pos (+ 1 (- current-line
+        (let* ((diff-pos (+ 1 (- first-line
                                  amount-loc
                                  (a-get obj 'head-pos))))
                (diff-end (when region-start
-                           (+ 1 (- (line-number-at-pos region-end)
+                           (+ 1 (- last-line
                                    amount-loc
                                    (a-get obj 'head-pos)))))
                (local-comment (code-review-local-comment-section
@@ -246,8 +264,7 @@ Optionally define a MSG."
                 (code-review-comment-add suggestion)
                 (with-current-buffer (get-buffer code-review-comment-buffer-name)
                   (forward-line -2)))
-            (code-review-comment-add)))))))
-
+            (code-review-comment-add))))))))
 
 ;;;###autoload
 (defun code-review-comment-add-or-edit (&optional suggestion-code?)

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -193,7 +193,9 @@ Optionally define a MSG."
   (with-slots (type) (magit-current-section)
     (if (not (equal type 'hunk))
         (message "You can't add text over unspecified region.")
-      (let* ((current-line (line-number-at-pos))
+      (let* ((region-start (and (region-active-p) (region-beginning)))
+             (region-end   (and (region-active-p) (region-end)))
+             (current-line (line-number-at-pos))
              (line (save-excursion
                      (buffer-substring-no-properties
                       (line-beginning-position)
@@ -226,11 +228,16 @@ Optionally define a MSG."
         (let* ((diff-pos (+ 1 (- current-line
                                  amount-loc
                                  (a-get obj 'head-pos))))
+               (diff-end (when region-start
+                           (+ 1 (- (line-number-at-pos region-end)
+                                   amount-loc
+                                   (a-get obj 'head-pos)))))
                (local-comment (code-review-local-comment-section
                                :state "LOCAL COMMENT"
                                :author (code-review-utils--git-get-user)
                                :path (a-get obj 'path)
                                :position diff-pos
+                               :line (and diff-end (> diff-end diff-pos) diff-end)
                                :line-type line-type
                                :send? code-review-comment-send?)))
           (setq code-review-comment-uncommitted local-comment)

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -256,6 +256,7 @@ Optionally define a MSG."
                                :path (a-get obj 'path)
                                :position diff-pos
                                :line file-line
+                               :end-line file-end
                                :line-type line-type
                                :send? code-review-comment-send?)))
           (setq code-review-comment-uncommitted local-comment)
@@ -321,6 +322,7 @@ Inform if a SUGGESTION-CODE? is being proposed."
                                           (path . ,(oref obj path))
                                           (position . ,(oref obj position))
                                           (line . ,(oref obj line))
+                                          (end-line . ,(oref obj end-line))
                                           (databaseId)
                                           (diffHunk)
                                           (outdated)

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -239,16 +239,22 @@ Optionally define a MSG."
         (let* ((diff-pos (+ 1 (- current-line
                                  amount-loc
                                  (a-get obj 'head-pos))))
+               (diff-end (and region-start
+                              (let ((e (+ 1 (- (line-number-at-pos region-end)
+                                               amount-loc
+                                               (a-get obj 'head-pos)))))
+                                (and (> e diff-pos) e))))
+               ;; Convert diff-relative positions to file line numbers
+               ;; hunk value = (about . ranges) where ranges = ((base?) (from) (to))
+               (to-start (car (car (last (cdr obj)))))
+               (file-line (+ to-start diff-pos -1))
+               (file-end  (and diff-end (+ to-start diff-end -1)))
                (local-comment (code-review-local-comment-section
                                :state "LOCAL COMMENT"
                                :author (code-review-utils--git-get-user)
                                :path (a-get obj 'path)
                                :position diff-pos
-                               :line (and region-start
-                                         (let ((end (+ 1 (- (line-number-at-pos region-end)
-                                                            amount-loc
-                                                            (a-get obj 'head-pos)))))
-                                           (and (> end diff-pos) end)))
+                               :line file-line
                                :line-type line-type
                                :send? code-review-comment-send?)))
           (setq code-review-comment-uncommitted local-comment)

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -216,7 +216,7 @@ Optionally define a MSG."
                               (save-excursion
                                 (goto-char region-start)
                                 (string-join
-                                 (-map (lambda (l) (substring l 1))
+                                 (mapcar (lambda (l) (substring l 1))
                                        (split-string
                                         (buffer-substring-no-properties
                                          (save-excursion

--- a/code-review-comment.el
+++ b/code-review-comment.el
@@ -195,9 +195,7 @@ Optionally define a MSG."
         (message "You can't add text over unspecified region.")
       (let* ((region-start (and (region-active-p) (region-beginning)))
              (region-end   (and (region-active-p) (region-end)))
-             ;; Use region lines when available, else current line
-             (first-line (line-number-at-pos (or region-start (point))))
-             (last-line  (line-number-at-pos (or region-end (point))))
+             (current-line (line-number-at-pos (or region-start (point))))
              (line (save-excursion
                      (when region-start (goto-char region-start))
                      (buffer-substring-no-properties
@@ -210,22 +208,17 @@ Optionally define a MSG."
                           "ADDED")
                          (t
                           "UNCHANGED")))
-             ;; Build suggestion from region text, stripping +/- prefix
              (suggestion
               (let ((code (if region-start
                               (save-excursion
                                 (goto-char region-start)
-                                (string-join
-                                 (mapcar (lambda (l) (substring l 1))
-                                       (split-string
-                                        (buffer-substring-no-properties
-                                         (save-excursion
-                                           (goto-char region-start)
-                                           (line-beginning-position))
-                                         (save-excursion
-                                           (goto-char region-end)
-                                           (line-end-position)))
-                                        "\n")))
+                                (let* ((s (line-beginning-position))
+                                       (e (progn (goto-char region-end) (line-end-position)))
+                                       (txt (buffer-substring-no-properties s e))
+                                       (lines (split-string txt "\n")))
+                                  (string-join
+                                   (mapcar (lambda (l) (if (> (length l) 1) (substring l 1) "")) lines)
+                                   "\n")))
                             (substring line 1))))
                 (format "%s\n\n```suggestion\n%s\n```\n"
                         code-review-comment-suggestion-msg code)))
@@ -243,19 +236,19 @@ Optionally define a MSG."
                     (setq amount-loc 0)
                   (setq amount-loc (or (oref value amount-loc) 0)))))))
 
-        (let* ((diff-pos (+ 1 (- first-line
+        (let* ((diff-pos (+ 1 (- current-line
                                  amount-loc
                                  (a-get obj 'head-pos))))
-               (diff-end (when region-start
-                           (+ 1 (- last-line
-                                   amount-loc
-                                   (a-get obj 'head-pos)))))
                (local-comment (code-review-local-comment-section
                                :state "LOCAL COMMENT"
                                :author (code-review-utils--git-get-user)
                                :path (a-get obj 'path)
                                :position diff-pos
-                               :line (and diff-end (> diff-end diff-pos) diff-end)
+                               :line (and region-start
+                                         (let ((end (+ 1 (- (line-number-at-pos region-end)
+                                                            amount-loc
+                                                            (a-get obj 'head-pos)))))
+                                           (and (> end diff-pos) end)))
                                :line-type line-type
                                :send? code-review-comment-send?)))
           (setq code-review-comment-uncommitted local-comment)
@@ -264,7 +257,8 @@ Optionally define a MSG."
                 (code-review-comment-add suggestion)
                 (with-current-buffer (get-buffer code-review-comment-buffer-name)
                   (forward-line -2)))
-            (code-review-comment-add))))))))
+            (code-review-comment-add)))))))
+
 
 ;;;###autoload
 (defun code-review-comment-add-or-edit (&optional suggestion-code?)

--- a/code-review-db.el
+++ b/code-review-db.el
@@ -236,9 +236,6 @@
 
 (defun code-review-db-all-unfinished ()
   "Get a list of all unfinished Reviews."
-  (when (and code-review-db-connection (emacsql-live-p code-review-db-connection))
-    (emacsql-close code-review-db-connection)
-    (setq code-review-db-connection nil))
   (let ((class 'code-review-db-pullreq)
         (db (code-review-db)))
     (->> (emacsql db

--- a/code-review-db.el
+++ b/code-review-db.el
@@ -30,7 +30,6 @@
 ;;; Code:
 
 (require 'a)
-(require 'emacsql-sqlite)
 (require 'closql)
 (require 'eieio)
 (require 'uuidgen)
@@ -117,7 +116,7 @@
    (buffer              :closql-class code-review-db-buffer))
   :abstract t)
 
-(defclass code-review-db-database (emacsql-sqlite-connection closql-database)
+(defclass code-review-db-database (closql-database)
   ((object-class :initform 'code-review-db-pullreq)))
 
 ;;; LOL, why? why did I started the database on version 7? :/

--- a/code-review-db.el
+++ b/code-review-db.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'a)
+(require 'emacsql-sqlite)
 (require 'closql)
 (require 'eieio)
 (require 'uuidgen)

--- a/code-review-db.el
+++ b/code-review-db.el
@@ -35,18 +35,11 @@
 (require 'uuidgen)
 (require 'dash)
 
-(defcustom code-review-db-database-connector 'sqlite
-  "The database connector."
-  :group 'code-review
-  :type 'keyword)
-
 (defcustom code-review-db-database-file
   (expand-file-name "code-review-db-file.sqlite" user-emacs-directory)
   "The file used to store the `code-review' database."
   :group 'code-review
   :type 'file)
-
-(declare-function code-review-db-database--eieio-childp "code-review-db.el" (obj) t)
 
 (defclass code-review-db-buffer (closql-object)
   ((closql-table        :initform 'buffer)
@@ -117,40 +110,21 @@
   :abstract t)
 
 (defclass code-review-db-database (closql-database)
-  ((object-class :initform 'code-review-db-pullreq)))
+  ((name         :initform "code-review-db")
+   (object-class :initform 'code-review-db-pullreq)
+   (file         :initform 'code-review-db-database-file)
+   (schemata     :initform 'code-review-db-table-schema)
+   (version      :initform 8)))
 
-;;; LOL, why? why did I started the database on version 7? :/
-;;; damn copy and paste from `forge-db'.
-(defconst code-review-db-version 8)
+(defvar code-review-db--override-connection-class nil)
 
-(defconst code-review-db--sqlite-available-p
-  (with-demoted-errors "Code Review initialization: %S"
-    (emacsql-sqlite-ensure-binary)
-    t))
+(defvar code-review-db--sqlite-available-p t)
 
-(defvar code-review-db-connection nil
-  "The EmacSQL database connection.")
-
-(defun code-review-db ()
-  "Start connection."
-  (unless (and code-review-db-connection (emacsql-live-p code-review-db-connection))
-    (make-directory (file-name-directory code-review-db-database-file) t)
-    (closql-db 'code-review-db-database 'code-review-db-connection
-               code-review-db-database-file t)
-    (let* ((db code-review-db-connection)
-           (version (closql--db-get-version db))
-           (version (code-review--db-maybe-update code-review-db-connection version)))
-      (cond
-       ((> version code-review-db-version)
-        (emacsql-close db)
-        (user-error
-         "The Code Review database was created with a newer Code Review version.  %s"
-         "You need to update the Code Review package."))
-       ((< version code-review-db-version)
-        (emacsql-close db)
-        (error "BUG: The Code Review database scheme changed %s"
-               "and there is no upgrade path.")))))
-  code-review-db-connection)
+(defun code-review-db (&optional livep)
+  (condition-case err
+      (closql-db 'code-review-db-database livep code-review-db--override-connection-class)
+    (error (setq code-review-db--sqlite-available-p nil)
+           (signal (car err) (cdr err)))))
 
 ;;; Schema
 
@@ -220,22 +194,17 @@
       [path] :references path [id]
       :on-delete :cascade))))
 
-(cl-defmethod closql--db-init ((db code-review-db-database))
-  "Initialize the DB."
-  (emacsql-with-transaction db
-    (pcase-dolist (`(,table . ,schema) code-review-db-table-schema)
-      (emacsql db [:create-table $i1 $S2] table schema))
-    (closql--db-set-version db code-review-db-version)))
-
-(defun code-review--db-maybe-update (db version)
-  (emacsql-with-transaction db
-    (when (= version 7)
-      (message "Upgrading Code Review database from version 7 to 8...")
-      (emacsql db [:alter-table pullreq :add-column base-ref-name :default nil])
-      (emacsql db [:alter-table pullreq :add-column head-ref-name :default nil])
-      (closql--db-set-version db (setq version 8))
-      (message "Upgrading Code Review database from version 7 to 8...done"))
-    version))
+(cl-defmethod closql--db-update-schema ((db code-review-db-database))
+  (let ((code-version (oref-default 'code-review-db-database version))
+        (version (closql--db-get-version db)))
+    (closql-with-transaction db
+      (when (= version 7)
+        (message "Upgrading Code Review database from version 7 to 8...")
+        (emacsql db [:alter-table pullreq :add-column base-ref-name :default nil])
+        (emacsql db [:alter-table pullreq :add-column head-ref-name :default nil])
+        (closql--db-set-version db (setq version 8))
+        (message "Upgrading Code Review database from version 7 to 8...done"))
+      (cl-call-next-method))))
 
 ;;; Core
 
@@ -436,12 +405,12 @@
                                           :buffer pr-id
                                           :name curr-path
                                           :at-pos-p t)))
-          (emacsql-with-transaction db
+          (closql-with-transaction db
             (closql-insert db buf t)
             (closql-insert db path t)))
       (let* ((paths (oref buf paths))
              (curr-path-re-enabled? nil))
-        (emacsql-with-transaction db
+        (closql-with-transaction db
           ;;; disable all previous ones and enable curr-path is already exists
           (-map
            (lambda (path)
@@ -542,7 +511,7 @@ Very Bad Performance!."
          (if written?
              t
            (when comment
-             (-contains-p (oref comment identifiers) identifier)))))
+             (and (-contains-p (oref comment identifiers) identifier) t)))))
      nil
      paths)))
 

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -776,8 +776,8 @@ Optionally ask for the FALLBACK? query."
                                              (line . ,start)))))
                                      (oref review local-comments)))
                                    (lambda (a b)
-                                     (< (a-get a 'position)
-                                        (a-get b 'position))))))
+                                     (< (or (a-get a 'start_line) (a-get a 'line) 0)
+                                        (or (a-get b 'start_line) (a-get b 'line) 0))))))
                         (append payload
                                 `((comments . [,@clist]))))
                     payload)))

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -782,7 +782,7 @@ Optionally ask for the FALLBACK? query."
                    :callback callback)
       (error
        (message "[code-review] SEND-REVIEW error: %S %S" (car err) (cdr err))
-       nil)))))
+       nil))))
 
 (cl-defmethod code-review-get-assignable-users ((github code-review-github-repo))
   "Get a list of assignable users for current PR in GITHUB."

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -188,13 +188,6 @@ https://github.com/wandersoncferreira/code-review#configuration"))
           login
         }
       }
-      projectCards(first: 10) {
-        nodes {
-          project {
-            name
-          }
-        }
-      }
       suggestedReviewers {
         reviewer {
           name
@@ -362,13 +355,6 @@ https://github.com/wandersoncferreira/code-review#configuration"))
           name
           login
           url
-        }
-      }
-      projectCards(first: 10) {
-        nodes {
-          project {
-            name
-          }
         }
       }
       suggestedReviewers {

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -753,21 +753,24 @@ Optionally ask for the FALLBACK? query."
 (cl-defmethod code-review-send-review ((review code-review-submit-github-review) callback)
   "Submit review comments given REVIEW and a CALLBACK fn."
   (let* ((pr (oref review pr))
-         ;; Build payload as a proper alist with dotted pairs throughout
-         (payload `((event . ,(oref review state))
-                    (commit_id . ,(oref pr sha))
-                    ,@(and (oref review feedback)
-                           `((body . ,(oref review feedback))))
-                    ,@(and (oref review local-comments)
-                           `((comments . ,(--sort
-                                          (< (a-get it 'position)
-                                             (a-get other 'position))
-                                          (-map
-                                           (lambda (c)
-                                             `((path . ,(oref c path))
-                                               (position . ,(oref c position))
-                                               (body . ,(oref c body))))
-                                           (oref review local-comments))))))))
+         (payload-base `((event . ,(oref review state))
+                         (commit_id . ,(oref pr sha))))
+         (payload (if (oref review feedback)
+                      (append payload-base
+                              `((body . ,(oref review feedback))))
+                    payload-base))
+         (payload (if (oref review local-comments)
+                      (append payload
+                              `((comments . ,(--sort
+                                            (< (a-get it 'position)
+                                               (a-get other 'position))
+                                            (-map
+                                             (lambda (c)
+                                               `((path . ,(oref c path))
+                                                 (position . ,(oref c position))
+                                                 (body . ,(oref c body))))
+                                             (oref review local-comments))))))
+                    payload)))
     (condition-case err
         (ghub-post (format "/repos/%s/%s/pulls/%s/reviews"
                            (oref pr owner)
@@ -781,7 +784,7 @@ Optionally ask for the FALLBACK? query."
                    :callback callback)
       (error
        (message "[code-review] SEND-REVIEW error: %S %S" (car err) (cdr err))
-       nil)))))
+       nil))))
 
 (cl-defmethod code-review-get-assignable-users ((github code-review-github-repo))
   "Get a list of assignable users for current PR in GITHUB."

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -753,22 +753,21 @@ Optionally ask for the FALLBACK? query."
 (cl-defmethod code-review-send-review ((review code-review-submit-github-review) callback)
   "Submit review comments given REVIEW and a CALLBACK fn."
   (let* ((pr (oref review pr))
-         (payload (a-alist 'event (oref review state)
-                           'commit_id (oref pr sha)))
-         (payload (if (oref review feedback)
-                      (a-assoc payload 'body (oref review feedback))
-                    payload))
-         (payload (if (oref review local-comments)
-                      (a-assoc payload 'comments (--sort
-                                                  (< (a-get it 'position)
-                                                     (a-get other 'position))
-                                                  (-map
-                                                   (lambda (c)
-                                                     `((path . ,(oref c path))
-                                                       (position . ,(oref c position))
-                                                       (body . ,(oref c body))))
-                                                   (oref review local-comments))))
-                    payload)))
+         ;; Build payload as a proper alist with dotted pairs throughout
+         (payload `((event . ,(oref review state))
+                    (commit_id . ,(oref pr sha))
+                    ,@(and (oref review feedback)
+                           `((body . ,(oref review feedback))))
+                    ,@(and (oref review local-comments)
+                           `((comments . ,(--sort
+                                          (< (a-get it 'position)
+                                             (a-get other 'position))
+                                          (-map
+                                           (lambda (c)
+                                             `((path . ,(oref c path))
+                                               (position . ,(oref c position))
+                                               (body . ,(oref c body))))
+                                           (oref review local-comments))))))))
     (condition-case err
         (ghub-post (format "/repos/%s/%s/pulls/%s/reviews"
                            (oref pr owner)
@@ -782,7 +781,7 @@ Optionally ask for the FALLBACK? query."
                    :callback callback)
       (error
        (message "[code-review] SEND-REVIEW error: %S %S" (car err) (cdr err))
-       nil))))
+       nil)))))
 
 (cl-defmethod code-review-get-assignable-users ((github code-review-github-repo))
   "Get a list of assignable users for current PR in GITHUB."

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -764,20 +764,16 @@ Optionally ask for the FALLBACK? query."
                                    (copy-sequence
                                     (-map
                                      (lambda (c)
-                                       (let ((start (oref c position))
+                                       (let ((start (oref c line))
                                              (end   (oref c line)))
-                                         (if end
-                                             `((path . ,(oref c path))
-                                               (body . ,(oref c body))
-                                               (start_line . ,start)
-                                               (line . ,end))
-                                           `((path . ,(oref c path))
-                                             (body . ,(oref c body))
-                                             (line . ,start)))))
+                                         ;; Use file-line for both; GitHub needs line
+                                         `((path . ,(oref c path))
+                                           (body . ,(oref c body))
+                                           (line . ,start))))
                                      (oref review local-comments)))
                                    (lambda (a b)
-                                     (< (or (a-get a 'start_line) (a-get a 'line) 0)
-                                        (or (a-get b 'start_line) (a-get b 'line) 0))))))
+                                     (< (a-get a 'line)
+                                        (a-get b 'line))))))
                         (append payload
                                 `((comments . [,@clist]))))
                     payload)))
@@ -939,18 +935,10 @@ Return the blob URL if BLOB? is provided."
                  :auth 'code-review
                  :headers '(("Accept" . "application/vnd.github.v3+json"))
                  :host code-review-github-host
-                 :payload (let ((start (oref local-comment position))
-                                (end   (oref local-comment line)))
-                            (if end
-                                `((path . ,(oref local-comment path))
-                                  (body . ,(oref local-comment msg))
-                                  (commit_id . ,(oref github sha))
-                                  (start_line . ,start)
-                                  (line . ,end))
-                              `((path . ,(oref local-comment path))
-                                (body . ,(oref local-comment msg))
-                                (commit_id . ,(oref github sha))
-                                (line . ,start))))
+                 :payload `((path . ,(oref local-comment path))
+                            (body . ,(oref local-comment msg))
+                            (commit_id . ,(oref github sha))
+                            (line . ,(oref local-comment line)))
                  :callback callback
                  :errorback #'code-review-github-errback)
     (error

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -724,7 +724,7 @@ Optionally ask for the FALLBACK? query."
                             nil
                             :payload (a-alist 'body (oref reply body))
                             :headers code-review-github-diffheader
-                            :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
+                            :auth 'code-review
                             :host code-review-github-host
                             :callback (lambda (&rest _))
                             :errorback #'code-review-github-errback)
@@ -777,7 +777,7 @@ Optionally ask for the FALLBACK? query."
                            (oref pr repo)
                            (oref pr number))
                    nil
-                   :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
+                   :auth 'code-review
                    :payload payload
                    :host code-review-github-host
                    :errorback #'code-review-github-errback

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -714,7 +714,7 @@ Optionally ask for the FALLBACK? query."
                         nil
                         :payload (a-alist 'body (oref reply body))
                         :headers code-review-github-diffheader
-                        :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
+                        :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
                         :host code-review-github-host
                         :callback (lambda (&rest _))
                         :errorback #'code-review-github-errback)))
@@ -761,7 +761,7 @@ Optionally ask for the FALLBACK? query."
                        (oref pr repo)
                        (oref pr number))
                nil
-               :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
+               :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
                :payload payload
                :host code-review-github-host
                :errorback #'code-review-github-errback

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -764,9 +764,16 @@ Optionally ask for the FALLBACK? query."
                                    (copy-sequence
                                     (-map
                                      (lambda (c)
-                                       `((path . ,(oref c path))
-                                         (position . ,(oref c position))
-                                         (body . ,(oref c body))))
+                                       (let ((start (oref c position))
+                                             (end   (oref c line)))
+                                         (if end
+                                             `((path . ,(oref c path))
+                                               (body . ,(oref c body))
+                                               (start_line . ,start)
+                                               (line . ,end))
+                                           `((path . ,(oref c path))
+                                             (body . ,(oref c body))
+                                             (line . ,start)))))
                                      (oref review local-comments)))
                                    (lambda (a b)
                                      (< (a-get a 'position)
@@ -929,13 +936,21 @@ Return the blob URL if BLOB? is provided."
                          (oref github repo)
                          (oref github number))
                  nil
-                 :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
+                 :auth 'code-review
                  :headers '(("Accept" . "application/vnd.github.v3+json"))
                  :host code-review-github-host
-                 :payload (a-alist 'path (oref local-comment path)
-                                   'position (oref local-comment position)
-                                   'body (oref local-comment msg)
-                                   'commit_id (oref github sha))
+                 :payload (let ((start (oref local-comment position))
+                                (end   (oref local-comment line)))
+                            (if end
+                                `((path . ,(oref local-comment path))
+                                  (body . ,(oref local-comment msg))
+                                  (commit_id . ,(oref github sha))
+                                  (start_line . ,start)
+                                  (line . ,end))
+                              `((path . ,(oref local-comment path))
+                                (body . ,(oref local-comment msg))
+                                (commit_id . ,(oref github sha))
+                                (line . ,start))))
                  :callback callback
                  :errorback #'code-review-github-errback)
     (error

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -760,16 +760,17 @@ Optionally ask for the FALLBACK? query."
                               `((body . ,(oref review feedback))))
                     payload-base))
          (payload (if (oref review local-comments)
-                      (append payload
-                              `((comments . ,(--sort
-                                            (< (a-get it 'position)
-                                               (a-get other 'position))
-                                            (-map
-                                             (lambda (c)
-                                               `((path . ,(oref c path))
-                                                 (position . ,(oref c position))
-                                                 (body . ,(oref c body))))
-                                             (oref review local-comments))))))
+                      (let ((clist (-sort
+                                   (< (a-get it 'position)
+                                      (a-get other 'position))
+                                   (-map
+                                    (lambda (c)
+                                      `((path . ,(oref c path))
+                                        (position . ,(oref c position))
+                                        (body . ,(oref c body))))
+                                    (oref review local-comments)))))
+                        (append payload
+                                `((comments . [,@clist]))))
                     payload)))
     (condition-case err
         (ghub-post (format "/repos/%s/%s/pulls/%s/reviews"

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -66,16 +66,25 @@
                        (a-get (-third-item .error) 'errors)
                        " AND "))
               (msg (string-trim (a-get (-third-item .error) 'message))))
-          (message "Errors: %S" (if (string-empty-p errors)
+          (message "[code-review] API 422: %S" (if (string-empty-p errors)
                                     msg
                                   (string-join (list msg errors) ". ")))))
        ((= status 404)
-        (message "Provided URL Not Found"))
+        (message "[code-review] API 404: resource not found"))
        ((= status 401)
-        (message "Bad credentials. Documentation to how to setup credentials
-https://github.com/wandersoncferreira/code-review#configuration"))
+        (message "[code-review] API 401: Bad credentials. See https://github.com/wandersoncferreira/code-review#configuration"))
        (t
-        (message "Unknown error talking to Github: %s" m))))))
+        (message "[code-review] API error: %s" (prin1-to-string m)))))))
+
+(defmacro code-review--with-visible-errors (&rest body)
+  "Execute BODY catching errors and showing them in minibuffer."
+  (declare (indent 0))
+  `(condition-case err
+       (progn ,@body)
+     (error
+      (message "[code-review] ERROR: %s %s" (car err) (cdr err))
+      (backtrace)))
+  )
 
 (cl-defmethod code-review-pullreq-diff ((github code-review-github-repo) callback)
   "Get PR diff from GITHUB, run CALLBACK after answer."
@@ -706,18 +715,22 @@ Optionally ask for the FALLBACK? query."
         (-map
          (lambda (reply)
            (lambda ()
-             (ghub-post (format "/repos/%s/%s/pulls/%s/comments/%s/replies"
-                                (oref pr owner)
-                                (oref pr repo)
-                                (oref pr number)
-                                (oref reply reply-to-id))
-                        nil
-                        :payload (a-alist 'body (oref reply body))
-                        :headers code-review-github-diffheader
-                        :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
-                        :host code-review-github-host
-                        :callback (lambda (&rest _))
-                        :errorback #'code-review-github-errback)))
+             (condition-case err
+                 (ghub-post (format "/repos/%s/%s/pulls/%s/comments/%s/replies"
+                                    (oref pr owner)
+                                    (oref pr repo)
+                                    (oref pr number)
+                                    (oref reply reply-to-id))
+                            nil
+                            :payload (a-alist 'body (oref reply body))
+                            :headers code-review-github-diffheader
+                            :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
+                            :host code-review-github-host
+                            :callback (lambda (&rest _))
+                            :errorback #'code-review-github-errback)
+               (error
+                (message "[code-review] SEND-REPLIES error: %S %S" (car err) (cdr err))
+                nil))))
          (oref replies replies)))
 
       (deferred:nextc it
@@ -726,7 +739,7 @@ Optionally ask for the FALLBACK? query."
 
       (deferred:error it
         (lambda (err)
-          (message "Got an error from the Github Reply API %S!" err))))))
+          (message "[code-review] SEND-REPLIES deferred error: %S" err))))))
 
 (defclass code-review-submit-github-review ()
   ((state :initform nil)
@@ -756,16 +769,20 @@ Optionally ask for the FALLBACK? query."
                                                        (body . ,(oref c body))))
                                                    (oref review local-comments))))
                     payload)))
-    (ghub-post (format "/repos/%s/%s/pulls/%s/reviews"
-                       (oref pr owner)
-                       (oref pr repo)
-                       (oref pr number))
-               nil
-               :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
-               :payload payload
-               :host code-review-github-host
-               :errorback #'code-review-github-errback
-               :callback callback)))
+    (condition-case err
+        (ghub-post (format "/repos/%s/%s/pulls/%s/reviews"
+                           (oref pr owner)
+                           (oref pr repo)
+                           (oref pr number))
+                   nil
+                   :auth (code-review-utils--get-auth-marker (oref pr owner) (oref pr repo))
+                   :payload payload
+                   :host code-review-github-host
+                   :errorback #'code-review-github-errback
+                   :callback callback)
+      (error
+       (message "[code-review] SEND-REVIEW error: %S %S" (car err) (cdr err))
+       nil)))))
 
 (cl-defmethod code-review-get-assignable-users ((github code-review-github-repo))
   "Get a list of assignable users for current PR in GITHUB."
@@ -901,20 +918,24 @@ Return the blob URL if BLOB? is provided."
 
 (cl-defmethod code-review-new-code-comment ((github code-review-github-repo) local-comment callback)
   "Creare a new code comment in GITHUB from a LOCAL-COMMENT and call CALLBACK."
-  (ghub-post (format "/repos/%s/%s/pulls/%s/comments"
-                     (oref github owner)
-                     (oref github repo)
-                     (oref github number))
-             nil
-             :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
-             :headers '(("Accept" . "application/vnd.github.v3+json"))
-             :host code-review-github-host
-             :payload (a-alist 'path (oref local-comment path)
-                               'position (oref local-comment position)
-                               'body (oref local-comment msg)
-                               'commit_id (oref github sha))
-             :callback callback
-             :errorback #'code-review-github-errback))
+  (condition-case err
+      (ghub-post (format "/repos/%s/%s/pulls/%s/comments"
+                         (oref github owner)
+                         (oref github repo)
+                         (oref github number))
+                 nil
+                 :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
+                 :headers '(("Accept" . "application/vnd.github.v3+json"))
+                 :host code-review-github-host
+                 :payload (a-alist 'path (oref local-comment path)
+                                   'position (oref local-comment position)
+                                   'body (oref local-comment msg)
+                                   'commit_id (oref github sha))
+                 :callback callback
+                 :errorback #'code-review-github-errback)
+    (error
+     (message "[code-review] NEW-CODE-COMMENT error: %S %S" (car err) (cdr err))
+     nil)))
 
 ;;; File viewed state (markFileAsViewed / unmarkFileAsViewed)
 
@@ -926,13 +947,37 @@ Return the blob URL if BLOB? is provided."
     pullRequest { id }
   }
 }"))
-    (ghub-graphql query
-                  `((input . ((pullRequestId . ,pr-id)
-                              (path . ,path))))
-                  :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
-                  :host code-review-github-graphql-host
-                  :callback (lambda (&rest _) (funcall callback))
-                  :errorback #'code-review-github-errback)))
+    (condition-case err
+        (ghub-graphql query
+                      `((input . ((pullRequestId . ,pr-id)
+                                  (path . ,path))))
+                      :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
+                      :host code-review-github-graphql-host
+                      :callback (lambda (&rest _) (funcall callback))
+                      :errorback #'code-review-github-errback)
+      (error
+       (message "[code-review] MARK-FILE-VIEWED error: %S %S" (car err) (cdr err))
+       nil))))
+
+(cl-defmethod code-review-unmark-file-viewed ((github code-review-github-repo) path callback)
+  "Unmark file PATH as viewed for GITHUB PR and call CALLBACK."
+  (let ((pr-id (a-get (oref github raw-infos) 'id))
+        (query "mutation($input: UnmarkFileAsViewedInput!) {
+  unmarkFileAsViewed(input: $input) {
+    pullRequest { id }
+  }
+}"))
+    (condition-case err
+        (ghub-graphql query
+                      `((input . ((pullRequestId . ,pr-id)
+                                  (path . ,path))))
+                      :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
+                      :host code-review-github-graphql-host
+                      :callback (lambda (&rest _) (funcall callback))
+                      :errorback #'code-review-github-errback)
+      (error
+       (message "[code-review] UNMARK-FILE-VIEWED error: %S %S" (car err) (cdr err))
+       nil))))
 
 (cl-defmethod code-review-unmark-file-viewed ((github code-review-github-repo) path callback)
   "Unmark file PATH as viewed for GITHUB PR and call CALLBACK."

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -929,5 +929,76 @@ Return the blob URL if BLOB? is provided."
              :callback callback
              :errorback #'code-review-github-errback))
 
+;;; File viewed state (markFileAsViewed / unmarkFileAsViewed)
+
+(cl-defmethod code-review-mark-file-viewed ((github code-review-github-repo) path callback)
+  "Mark file PATH as viewed for GITHUB PR and call CALLBACK."
+  (let ((pr-id (a-get (oref github raw-infos) 'id))
+        (query "mutation($input: MarkFileAsViewedInput!) {
+  markFileAsViewed(input: $input) {
+    pullRequest { id }
+  }
+}"))
+    (ghub-graphql query
+                  `((input . ((pullRequestId . ,pr-id)
+                              (path . ,path))))
+                  :auth code-review-auth-login-marker
+                  :host code-review-github-graphql-host
+                  :callback (lambda (&rest _) (funcall callback))
+                  :errorback #'code-review-github-errback)))
+
+(cl-defmethod code-review-unmark-file-viewed ((github code-review-github-repo) path callback)
+  "Unmark file PATH as viewed for GITHUB PR and call CALLBACK."
+  (let ((pr-id (a-get (oref github raw-infos) 'id))
+        (query "mutation($input: UnmarkFileAsViewedInput!) {
+  unmarkFileAsViewed(input: $input) {
+    pullRequest { id }
+  }
+}"))
+    (ghub-graphql query
+                  `((input . ((pullRequestId . ,pr-id)
+                              (path . ,path))))
+                  :auth code-review-auth-login-marker
+                  :host code-review-github-graphql-host
+                  :callback (lambda (&rest _) (funcall callback))
+                  :errorback #'code-review-github-errback)))
+
+(cl-defmethod code-review-fetch-viewed-files ((github code-review-github-repo) callback)
+  "Fetch viewerViewedState for all files in GITHUB PR and call CALLBACK.
+CALLBACK receives an alist of ((path . viewed-p) ...)."
+  (let* ((owner (oref github owner))
+         (repo (oref github repo))
+         (num (if (numberp (oref github number))
+                  (oref github number)
+                (string-to-number (oref github number))))
+         (query "query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      files(first: 100) {
+        nodes {
+          path
+          viewerViewedState
+        }
+      }
+    }
+  }
+}"))
+    (ghub-graphql query
+                  `((owner . ,owner)
+                    (name . ,repo)
+                    (pr . ,num))
+                  :auth code-review-auth-login-marker
+                  :host code-review-github-graphql-host
+                  :callback (lambda (res &rest _)
+                              (let ((files (a-get-in res (list 'data 'repository 'pullRequest 'files 'nodes)))
+                                    (result nil))
+                                (dolist (f files)
+                                  (push (cons (a-get f 'path)
+                                              (string= (a-get f 'viewerViewedState) "VIEWED"))
+                                        result))
+                                (funcall callback result)))
+                  :errorback (lambda (&rest _)
+                               (funcall callback nil)))))
+
 (provide 'code-review-github)
 ;;; code-review-github.el ends here

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -765,11 +765,13 @@ Optionally ask for the FALLBACK? query."
                                     (-map
                                      (lambda (c)
                                        (let ((start (oref c line))
-                                             (end   (oref c line)))
-                                         ;; Use file-line for both; GitHub needs line
+                                             (end   (oref c end-line)))
                                          `((path . ,(oref c path))
                                            (body . ,(oref c body))
-                                           (line . ,start))))
+                                           ,@(if end
+                                                 `((start_line . ,start)
+                                                   (line . ,end))
+                                               `((line . ,start))))))
                                      (oref review local-comments)))
                                    (lambda (a b)
                                      (< (a-get a 'line)
@@ -935,10 +937,14 @@ Return the blob URL if BLOB? is provided."
                  :auth 'code-review
                  :headers '(("Accept" . "application/vnd.github.v3+json"))
                  :host code-review-github-host
-                 :payload `((path . ,(oref local-comment path))
-                            (body . ,(oref local-comment msg))
-                            (commit_id . ,(oref github sha))
-                            (line . ,(oref local-comment line)))
+                 :payload (let ((start (oref local-comment line))
+                                (end   (oref local-comment end-line)))
+                            `((path . ,(oref local-comment path))
+                              (body . ,(oref local-comment msg))
+                              (commit_id . ,(oref github sha))
+                              ,@(if end
+                                    `((start_line . ,start) (line . ,end))
+                                  `((line . ,start)))))
                  :callback callback
                  :errorback #'code-review-github-errback)
     (error

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -760,15 +760,17 @@ Optionally ask for the FALLBACK? query."
                               `((body . ,(oref review feedback))))
                     payload-base))
          (payload (if (oref review local-comments)
-                      (let ((clist (-sort
-                                   (< (a-get it 'position)
-                                      (a-get other 'position))
-                                   (-map
-                                    (lambda (c)
-                                      `((path . ,(oref c path))
-                                        (position . ,(oref c position))
-                                        (body . ,(oref c body))))
-                                    (oref review local-comments)))))
+                      (let ((clist (sort
+                                   (copy-sequence
+                                    (-map
+                                     (lambda (c)
+                                       `((path . ,(oref c path))
+                                         (position . ,(oref c position))
+                                         (body . ,(oref c body))))
+                                     (oref review local-comments)))
+                                   (lambda (a b)
+                                     (< (a-get a 'position)
+                                        (a-get b 'position))))))
                         (append payload
                                 `((comments . [,@clist]))))
                     payload)))

--- a/code-review-github.el
+++ b/code-review-github.el
@@ -33,6 +33,7 @@
 (require 'code-review-interfaces)
 (require 'code-review-db)
 (require 'a)
+(require 'code-review-utils)
 
 (defclass code-review-github-repo (code-review-db-pullreq)
   ((callback            :initform nil)))
@@ -85,7 +86,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
               nil
               :unpaginate t
               :headers code-review-github-diffheader
-              :auth code-review-auth-login-marker
+              :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
               :host code-review-github-host
               :callback callback
               :errorback #'code-review-github-errback)))
@@ -110,7 +111,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
               nil
               :unpaginate t
               :headers code-review-github-diffheader
-              :auth code-review-auth-login-marker
+              :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
               :host code-review-github-host
               :callback callback
               :errorback #'code-review-github-errback)))
@@ -497,7 +498,7 @@ https://github.com/wandersoncferreira/code-review#configuration"))
                   num)))
     (ghub-graphql query
                   nil
-                  :auth code-review-auth-login-marker
+                  :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                   :host code-review-github-graphql-host
                   :callback callback
                   :errorback #'code-review-github-errback)))
@@ -521,7 +522,7 @@ Optionally ask for the FALLBACK? query."
                            (oref github owner)
                            (oref github repo))
                    nil
-                   :auth code-review-auth-login-marker
+                   :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                    :host code-review-github-host
                    :noerror 'return)))
     (if (eq (car (-first-item resp)) 'message)
@@ -547,7 +548,7 @@ Optionally ask for the FALLBACK? query."
                                                    (a-get x 'name))
                                                  (oref github labels))
                                            []))
-             :auth code-review-auth-login-marker
+             :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
              :host code-review-github-host
              :errorback #'code-review-github-errback
              :callback (lambda (&rest _) (funcall callback)))))
@@ -559,7 +560,7 @@ Optionally ask for the FALLBACK? query."
                            (oref github owner)
                            (oref github repo))
                    nil
-                   :auth code-review-auth-login-marker
+                   :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                    :host code-review-github-host
                    :noerror 'return)))
     (if (eq (car (-first-item resp)) 'message)
@@ -577,7 +578,7 @@ Optionally ask for the FALLBACK? query."
                      (oref github repo)
                      (oref github number))
              nil
-             :auth code-review-auth-login-marker
+             :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
              :host code-review-github-host
              :payload (a-alist 'assignees (-map (lambda (it)
                                                   (a-get it 'login))
@@ -592,7 +593,7 @@ Optionally ask for the FALLBACK? query."
                            (oref github owner)
                            (oref github repo))
                    nil
-                   :auth code-review-auth-login-marker
+                   :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                    :host code-review-github-host
                    :noerror 'return)))
     (if (eq (car (-first-item resp)) 'message)
@@ -610,7 +611,7 @@ Optionally ask for the FALLBACK? query."
                       (oref github repo)
                       (oref github number))
               nil
-              :auth code-review-auth-login-marker
+              :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
               :host code-review-github-host
               :payload (a-alist 'milestone (a-get (oref github milestones) 'number))
               :errorback #'code-review-github-errback
@@ -627,7 +628,7 @@ Optionally ask for the FALLBACK? query."
                       (oref github repo)
                       (oref github number))
               nil
-              :auth code-review-auth-login-marker
+              :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
               :host code-review-github-host
               :payload (a-alist 'title (oref github title))
               :errorback #'code-review-github-errback
@@ -641,7 +642,7 @@ Optionally ask for the FALLBACK? query."
                       (oref github repo)
                       (oref github number))
               nil
-              :auth code-review-auth-login-marker
+              :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
               :host code-review-github-host
               :payload (a-alist 'body (a-get (oref github raw-infos) 'bodyText))
               :errorback #'code-review-github-errback
@@ -654,7 +655,7 @@ Optionally ask for the FALLBACK? query."
                     (oref github repo)
                     (oref github number))
             nil
-            :auth code-review-auth-login-marker
+            :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
             :host code-review-github-host
             :payload (a-alist 'commit_title (oref github title)
                               'commit_message (oref github description)
@@ -683,7 +684,7 @@ Optionally ask for the FALLBACK? query."
                        (oref github repo)
                        path)
                nil
-               :auth code-review-auth-login-marker
+               :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                :host code-review-github-host
                :payload (a-alist 'content r))))
 
@@ -701,7 +702,7 @@ Optionally ask for the FALLBACK? query."
                          (oref github repo)
                          path)
                  nil
-                 :auth code-review-auth-login-marker
+                 :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                  :host code-review-github-host)))
 
 (defclass code-review-submit-github-replies ()
@@ -727,7 +728,7 @@ Optionally ask for the FALLBACK? query."
                         nil
                         :payload (a-alist 'body (oref reply body))
                         :headers code-review-github-diffheader
-                        :auth code-review-auth-login-marker
+                        :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                         :host code-review-github-host
                         :callback (lambda (&rest _))
                         :errorback #'code-review-github-errback)))
@@ -774,7 +775,7 @@ Optionally ask for the FALLBACK? query."
                        (oref pr repo)
                        (oref pr number))
                nil
-               :auth code-review-auth-login-marker
+               :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                :payload payload
                :host code-review-github-host
                :errorback #'code-review-github-errback
@@ -807,7 +808,7 @@ Optionally ask for the FALLBACK? query."
                                            `((repo_owner . ,(oref github owner))
                                              (repo_name . ,(oref github repo))
                                              (cursor . ,cursor))
-                                           :auth code-review-auth-login-marker
+                                           :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                                            :host code-review-github-graphql-host)))
             (let-alist graphql-res
               (setq has-next-page .data.repository.assignableUsers.pageInfo.hasNextPage
@@ -831,7 +832,7 @@ Optionally ask for the FALLBACK? query."
     (ghub-graphql query
                   `((input . ((pullRequestId . ,pr-id)
                               (userIds . ,user-ids))))
-                  :auth code-review-auth-login-marker
+                  :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                   :host code-review-github-graphql-host
                   :callback (lambda (&rest _)
                               (message "Review requested successfully!")
@@ -844,7 +845,7 @@ Optionally ask for the FALLBACK? query."
                      (oref github owner)
                      (oref github repo))
              nil
-             :auth code-review-auth-login-marker
+             :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
              :host code-review-github-host
              :payload (a-alist 'body body 'title title)
              :errorback #'code-review-github-errback
@@ -906,7 +907,7 @@ Return the blob URL if BLOB? is provided."
                      (oref github repo)
                      (oref github number))
              nil
-             :auth code-review-auth-login-marker
+             :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
              :host code-review-github-host
              :payload (a-alist 'body comment-msg)
              :callback callback
@@ -919,7 +920,7 @@ Return the blob URL if BLOB? is provided."
                      (oref github repo)
                      (oref github number))
              nil
-             :auth code-review-auth-login-marker
+             :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
              :headers '(("Accept" . "application/vnd.github.v3+json"))
              :host code-review-github-host
              :payload (a-alist 'path (oref local-comment path)
@@ -942,7 +943,7 @@ Return the blob URL if BLOB? is provided."
     (ghub-graphql query
                   `((input . ((pullRequestId . ,pr-id)
                               (path . ,path))))
-                  :auth code-review-auth-login-marker
+                  :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                   :host code-review-github-graphql-host
                   :callback (lambda (&rest _) (funcall callback))
                   :errorback #'code-review-github-errback)))
@@ -958,7 +959,7 @@ Return the blob URL if BLOB? is provided."
     (ghub-graphql query
                   `((input . ((pullRequestId . ,pr-id)
                               (path . ,path))))
-                  :auth code-review-auth-login-marker
+                  :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                   :host code-review-github-graphql-host
                   :callback (lambda (&rest _) (funcall callback))
                   :errorback #'code-review-github-errback)))
@@ -987,7 +988,7 @@ CALLBACK receives an alist of ((path . viewed-p) ...)."
                   `((owner . ,owner)
                     (name . ,repo)
                     (pr . ,num))
-                  :auth code-review-auth-login-marker
+                  :auth (code-review-utils--get-auth-marker (oref github owner) (oref github repo))
                   :host code-review-github-graphql-host
                   :callback (lambda (res &rest _)
                               (let ((files (a-get-in res (list 'data 'repository 'pullRequest 'files 'nodes)))

--- a/code-review-interfaces.el
+++ b/code-review-interfaces.el
@@ -108,5 +108,14 @@
 (cl-defgeneric code-review-new-code-comment (obj local-comment callback)
   "Create a new diff comment for OBJ given a LOCAL-COMMENT and call CALLBACK.")
 
+(cl-defgeneric code-review-mark-file-viewed (obj path callback)
+  "Mark file PATH as viewed for the PR in OBJ and call CALLBACK afterward.")
+
+(cl-defgeneric code-review-unmark-file-viewed (obj path callback)
+  "Unmark file PATH as viewed for the PR in OBJ and call CALLBACK afterward.")
+
+(cl-defgeneric code-review-fetch-viewed-files (obj callback)
+  "Fetch viewerViewedState for all files in PR OBJ and call CALLBACK with alist of (path . viewed-p).")
+
 (provide 'code-review-interfaces)
 ;;; code-review-interfaces.el ends here

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1406,6 +1406,11 @@ We need PATH-NAME, MISSING-PATHS, and GROUPED-COMMENTS to make this work."
 ;;; in wrong faces (diff-added / diff-removed / diff-context) on comments.
 ;;; See https://github.com/wandersoncferreira/code-review/issues/...
 
+;;; Use `with-eval-after-load' to avoid issues with Doom's incremental
+;;; loader, which may process top-level forms before magit is fully
+;;; loaded; `magit-hunk-section' would not be defined yet.
+
+(with-eval-after-load 'magit-diff
 (cl-defmethod magit-section-paint ((section magit-hunk-section) highlight)
   (unless magit-diff-highlight-hunk-body
     (setq highlight nil))

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1908,9 +1908,12 @@ If you want to provide a MSG for the end of the process."
   "Add a viewed CHECK MARK overlay before the file heading for PATH."
   (save-excursion
     (goto-char (point-min))
+    ;; For renamed files the line is "renamed  old/path -> new/path",
+    ;; but `path` is the new/current path after rename.  Allow optional
+    ;; "orig -> " prefix before the target path.
     (while (re-search-forward
             (concat "^[ \t]*\\(modified\\|added\\|deleted\\|renamed\\|new file\\|copied\\)"
-                    "[ \t]+" (regexp-quote path) "$")
+                    "[ \t]+\\(?:.* -> \\)?" (regexp-quote path) "$")
             nil t)
       (let ((start (match-beginning 0)))
         (unless (code-review--viewed-overlay-for path)

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1400,70 +1400,41 @@ We need PATH-NAME, MISSING-PATHS, and GROUPED-COMMENTS to make this work."
        comment-written-pos)
       (push path-pos code-review-section-hold-written-comment-ids))))
 
-;;; Override `magit-section-paint' for hunk sections to skip nested
-;;; comment sections inserted by code-review.  The default method paints
-;;; ALL lines in the hunk section, including comment text, which results
-;;; in wrong faces (diff-added / diff-removed / diff-context) on comments.
-;;; See https://github.com/wandersoncferreira/code-review/issues/...
+;;; After `magit-section-paint' paints a hunk, fix faces on any nested
+;;; comment sections so they don't end up with wrong diff faces.
+;;; (We use advice instead of `cl-defmethod' to avoid triggering
+;;;  Doom's incremental loader with the `magit-hunk-section' class.)
 
-;;; Use `with-eval-after-load' to avoid issues with Doom's incremental
-;;; loader, which may process top-level forms before magit is fully
-;;; loaded; `magit-hunk-section' would not be defined yet.
-
-(with-eval-after-load 'magit-diff
-(cl-defmethod magit-section-paint ((section magit-hunk-section) highlight)
-  (unless magit-diff-highlight-hunk-body
-    (setq highlight nil))
-  (let ((end (oref section end))
-        (merging (looking-at "@@@"))
-        (diff-type (magit-diff-type))
-        (stage nil)
-        (tab-width (magit-diff-tab-width
-                    (magit-section-parent-value section))))
-    (forward-line)
-    (while (< (point) end)
-      (let ((current (magit-current-section)))
-        (cond
-         ;; Point is inside a nested section (e.g. code-review comment).
-         ;; Skip to end of that section instead of painting it.
-         ((and current (not (eq current section)))
-          (ignore-errors
-            (goto-char (oref current end))))
-         (t
-          (when (and magit-diff-hide-trailing-cr-characters
-                     (char-equal ?\r (char-before (line-end-position))))
-            (put-text-property (1- (line-end-position)) (line-end-position)
-                               'invisible t))
-          (put-text-property
-           (point) (1+ (line-end-position)) 'font-lock-face
-           (cond
-            ((looking-at "^\\+\\+?\\([<=|>]\\)\\{7\\}")
-             (setq stage (pcase (list (match-string 1) highlight)
-                           ('("<" nil) 'magit-diff-our)
-                           ('("<"   t) 'magit-diff-our-highlight)
-                           ('("|" nil) 'magit-diff-base)
-                           ('("|"   t) 'magit-diff-base-highlight)
-                           ('("=" nil) 'magit-diff-their)
-                           ('("="   t) 'magit-diff-their-highlight)
-                           ('(">" nil) nil)))
-             'magit-diff-conflict-heading)
-            ((looking-at (if merging "^\\(\\+\\| \\+\\)" "^\\+"))
-             (magit-diff-paint-tab merging tab-width)
-             (magit-diff-paint-whitespace merging 'added diff-type)
-             (or stage
-                 (if highlight 'magit-diff-added-highlight 'magit-diff-added)))
-            ((looking-at (if merging "^\\(-\\| -\\)" "^-"))
-             (magit-diff-paint-tab merging tab-width)
-             (magit-diff-paint-whitespace merging 'removed diff-type)
-             (if highlight 'magit-diff-removed-highlight 'magit-diff-removed))
-            (t
-             (magit-diff-paint-tab merging tab-width)
-             (magit-diff-paint-whitespace merging 'context diff-type)
-             (if highlight 'magit-diff-context-highlight 'magit-diff-context))))
-          (forward-line)))))))
-  (when (eq magit-diff-refine-hunk 'all)
-    (magit-diff-update-hunk-refinement section))
-  (oset section painted (if highlight 'highlight 'plain)))
+(defun cr--fix-hunk-nested-comment-faces (section highlight)
+  "After `magit-section-paint' painted a hunk, fix faces on nested comment sections.
+Without this, comment text inside a hunk gets diff faces."
+  (when (and (cl-typep section 'magit-hunk-section)
+             (derived-mode-p 'code-review-mode))
+    (let ((end (oref section end))
+          (default-face (if highlight
+                            'magit-diff-context-highlight
+                          'magit-diff-context)))
+      (save-excursion
+        (goto-char (oref section start))
+        (forward-line) ; skip heading
+        (while (< (point) end)
+          (let ((current (magit-current-section)))
+            (if (and current (not (eq current section)))
+                ;; Point is inside a nested section — fix its face
+                (let ((nested-end (oref current end)))
+                  (while (< (point) nested-end)
+                    (let ((face (get-text-property (point) 'font-lock-face)))
+                      ;; Only replace if the line has a wrong diff face
+                      (when (memq face '(magit-diff-added
+                                         magit-diff-added-highlight
+                                         magit-diff-removed
+                                         magit-diff-removed-highlight
+                                         magit-diff-context
+                                         magit-diff-context-highlight))
+                        (put-text-property (point) (1+ (line-end-position))
+                                           'font-lock-face default-face)))
+                    (forward-line)))
+              (forward-line))))))))
 
 (defun code-review-section-insert-comment (comments amount-loc)
   "Insert COMMENTS to PULLREQ-ID keep the AMOUNT-LOC of comments written.
@@ -1665,6 +1636,9 @@ If you want to display a minibuffer MSG in the end."
         ;; advices
         (advice-add 'magit-diff-insert-file-section :override #'code-review-section--magit-diff-insert-file-section)
         (advice-add 'magit-diff-wash-hunk :override #'code-review-section--magit-diff-wash-hunk)
+        (unless (get 'magit-section-paint 'cr--fix-hunk-advice-installed)
+          (put 'magit-section-paint 'cr--fix-hunk-advice-installed t)
+          (advice-add 'magit-section-paint :after 'cr--fix-hunk-nested-comment-faces))
 
         (setq code-review-section-grouped-comments
               (code-review-utils-make-group

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1871,7 +1871,7 @@ If you want to provide a MSG for the end of the process."
   (save-excursion
     (goto-char (point-min))
     (while (re-search-forward
-            (concat "^[ \t]*\\(modified\\|added\\|deleted\\|renamed\\)"
+            (concat "^[ \t]*\\(modified\\|added\\|deleted\\|renamed\\|new file\\|copied\\)"
                     "[ \t]+" (regexp-quote path) "$")
             nil t)
       (let ((start (match-beginning 0)))

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -911,6 +911,9 @@ INDENT count of spaces are added at the start of every line."
                :type string)
    (position   :initarg :position
                :type number)
+   (line       :initarg :line
+               :initform nil
+               :documentation "End line for multi-line comments (range)")
    (reactions  :initarg :reactions
                :type (or null
                          (satisfies

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1845,5 +1845,68 @@ If you want to provide a MSG for the end of the process."
       (code-review-db-delete-raw-comment (oref value internalId))
       (code-review--build-buffer))))
 
+;;;
+;;;; * File viewed state overlays
+;;;
+
+(defvar code-review-section--viewed-files nil
+  "Alist of (path . viewed-p) tracking files marked as viewed.")
+
+(defun code-review--viewed-overlay-for (path)
+  "Find existing viewed overlay for PATH or nil."
+  (cl-find-if
+   (lambda (ov)
+     (string= (overlay-get ov 'cr-path) path))
+   (overlays-in (point-min) (point-max))))
+
+(defun code-review--remove-viewed-overlay (path)
+  "Remove viewed overlay for PATH."
+  (when-let (ov (code-review--viewed-overlay-for path))
+    (delete-overlay ov)
+    (let ((pair (assoc path code-review-section--viewed-files)))
+      (when pair (setcdr pair nil)))))
+
+(defun code-review--add-viewed-overlay (path)
+  "Add a viewed CHECK MARK overlay before the file heading for PATH."
+  (save-excursion
+    (goto-char (point-min))
+    (while (re-search-forward
+            (concat "^[ \t]*\\(modified\\|added\\|deleted\\|renamed\\)"
+                    "[ \t]+" (regexp-quote path) "$")
+            nil t)
+      (let ((start (match-beginning 0)))
+        (unless (code-review--viewed-overlay-for path)
+          (let ((ov (make-overlay start (1+ start)))
+                (pair (assoc path code-review-section--viewed-files)))
+            (overlay-put ov 'cr-path path)
+            (overlay-put ov 'evaporate t)
+            (overlay-put ov 'before-string
+                         (propertize " \u2713 " 'face '(:foreground "green" :weight bold)))
+            (if pair
+                (setcdr pair t)
+              (push (cons path t) code-review-section--viewed-files))))))))
+
+;;;###autoload
+(defun code-review-section-fetch-viewed-files (&rest _)
+  "Fetch viewed file state from GitHub and add check-mark overlays.
+Safe to call from `code-review-mode-hook' — errors are caught and logged."
+  (condition-case err
+      (when-let* ((pr (ignore-errors (code-review-db-get-pullreq)))
+                  ((code-review-github-repo-p pr)))
+        (code-review-fetch-viewed-files
+         pr
+         (lambda (files)
+           (when files
+             (setq code-review-section--viewed-files files)
+             (with-current-buffer code-review-buffer-name
+               (dolist (pair files)
+                 (when (cdr pair)
+                   (code-review--add-viewed-overlay (car pair)))))))))
+    (error
+     (code-review-utils--log "code-review-section-fetch-viewed-files"
+                            (format "Error: %S" err)))))
+
+(add-hook 'code-review-mode-hook #'code-review-section-fetch-viewed-files)
+
 (provide 'code-review-section)
 ;;; code-review-section.el ends here

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -913,7 +913,13 @@ INDENT count of spaces are added at the start of every line."
                :type number)
    (line       :initarg :line
                :initform nil
-               :documentation "End line for multi-line comments (range)")
+               :documentation "Start line for multi-line comments (file line)")
+   (end-line   :initarg :end-line
+               :initform nil
+               :documentation "End file line for multi-line range")
+   (end-line   :initarg :end-line
+               :initform nil
+               :documentation "End file line for multi-line range")
    (reactions  :initarg :reactions
                :type (or null
                          (satisfies

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1400,6 +1400,66 @@ We need PATH-NAME, MISSING-PATHS, and GROUPED-COMMENTS to make this work."
        comment-written-pos)
       (push path-pos code-review-section-hold-written-comment-ids))))
 
+;;; Override `magit-section-paint' for hunk sections to skip nested
+;;; comment sections inserted by code-review.  The default method paints
+;;; ALL lines in the hunk section, including comment text, which results
+;;; in wrong faces (diff-added / diff-removed / diff-context) on comments.
+;;; See https://github.com/wandersoncferreira/code-review/issues/...
+
+(cl-defmethod magit-section-paint ((section magit-hunk-section) highlight)
+  (unless magit-diff-highlight-hunk-body
+    (setq highlight nil))
+  (let ((end (oref section end))
+        (merging (looking-at "@@@"))
+        (diff-type (magit-diff-type))
+        (stage nil)
+        (tab-width (magit-diff-tab-width
+                    (magit-section-parent-value section))))
+    (forward-line)
+    (while (< (point) end)
+      (let ((current (magit-current-section)))
+        (cond
+         ;; Point is inside a nested section (e.g. code-review comment).
+         ;; Skip to end of that section instead of painting it.
+         ((and current (not (eq current section)))
+          (ignore-errors
+            (goto-char (oref current end))))
+         (t
+          (when (and magit-diff-hide-trailing-cr-characters
+                     (char-equal ?\r (char-before (line-end-position))))
+            (put-text-property (1- (line-end-position)) (line-end-position)
+                               'invisible t))
+          (put-text-property
+           (point) (1+ (line-end-position)) 'font-lock-face
+           (cond
+            ((looking-at "^\\+\\+?\\([<=|>]\\)\\{7\\}")
+             (setq stage (pcase (list (match-string 1) highlight)
+                           ('("<" nil) 'magit-diff-our)
+                           ('("<"   t) 'magit-diff-our-highlight)
+                           ('("|" nil) 'magit-diff-base)
+                           ('("|"   t) 'magit-diff-base-highlight)
+                           ('("=" nil) 'magit-diff-their)
+                           ('("="   t) 'magit-diff-their-highlight)
+                           ('(">" nil) nil)))
+             'magit-diff-conflict-heading)
+            ((looking-at (if merging "^\\(\\+\\| \\+\\)" "^\\+"))
+             (magit-diff-paint-tab merging tab-width)
+             (magit-diff-paint-whitespace merging 'added diff-type)
+             (or stage
+                 (if highlight 'magit-diff-added-highlight 'magit-diff-added)))
+            ((looking-at (if merging "^\\(-\\| -\\)" "^-"))
+             (magit-diff-paint-tab merging tab-width)
+             (magit-diff-paint-whitespace merging 'removed diff-type)
+             (if highlight 'magit-diff-removed-highlight 'magit-diff-removed))
+            (t
+             (magit-diff-paint-tab merging tab-width)
+             (magit-diff-paint-whitespace merging 'context diff-type)
+             (if highlight 'magit-diff-context-highlight 'magit-diff-context))))
+          (forward-line)))))))
+  (when (eq magit-diff-refine-hunk 'all)
+    (magit-diff-update-hunk-refinement section))
+  (oset section painted (if highlight 'highlight 'plain)))
+
 (defun code-review-section-insert-comment (comments amount-loc)
   "Insert COMMENTS to PULLREQ-ID keep the AMOUNT-LOC of comments written.
 A quite good assumption: every comment in an outdated hunk will be outdated."
@@ -1578,7 +1638,6 @@ Please Report this Bug" path-name))
 
         ;;; --- end -- code-review specific code.
           (oset section end (point))
-          (oset section washer 'magit-diff-paint-hunk)
           (oset section combined combined)
           (if combined
               (oset section from-ranges (butlast ranges))

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1676,9 +1676,9 @@ If you want to display a minibuffer MSG in the end."
             raw-infos-complete)))
 
     (when errors-complete-query
+      (message "GraphQL ERRORS: %s" (prin1-to-string errors-complete-query))
       (code-review-utils--log "code-review--internal-build"
-                        (format "Data returned by GraphQL API: \n %s" (prin1-to-string res)))
-      (message "GraphQL Github data contains errors. See `code-review-log-file' for details."))
+                        (format "Data returned by GraphQL API: \n %s" (prin1-to-string res))))
 
     ;; verify must have value!
     (let-alist raw-infos

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1886,6 +1886,35 @@ If you want to provide a MSG for the end of the process."
                 (setcdr pair t)
               (push (cons path t) code-review-section--viewed-files))))))))
 
+(defun code-review-section--total-files ()
+  "Return total number of changed files in current PR from GraphQL data."
+  (when-let* ((pr (ignore-errors (code-review-db-get-pullreq)))
+              (raw (oref pr raw-infos))
+              (files (a-get-in raw '(files nodes))))
+    (length files)))
+
+(defun code-review-section--viewed-count ()
+  "Return count of files currently marked as viewed."
+  (length (-filter #'cdr code-review-section--viewed-files)))
+
+(defun code-review-section--update-viewed-counter ()
+  "Update header-line-format to show viewed/total counter."
+  (condition-case nil
+      (when-let* ((pr (code-review-db-get-pullreq))
+                  (total (code-review-section--total-files))
+                  ((> total 0)))
+        (let* ((viewed (code-review-section--viewed-count))
+               (title (format "#%s: %s" (oref pr number) (oref pr title)))
+               (counter (format "  [%s/%s viewed]"
+                                (propertize (number-to-string viewed)
+                                            'face '(:foreground "green" :weight bold))
+                                (propertize (number-to-string total)
+                                            'face '(:foreground "dim gray")))))
+          (setq header-line-format
+                (propertize (concat title counter)
+                            'font-lock-face 'magit-section-heading))))
+    (error nil)))
+
 ;;;###autoload
 (defun code-review-section-fetch-viewed-files (&rest _)
   "Fetch viewed file state from GitHub and add check-mark overlays.
@@ -1901,7 +1930,8 @@ Safe to call from `code-review-mode-hook' — errors are caught and logged."
              (with-current-buffer code-review-buffer-name
                (dolist (pair files)
                  (when (cdr pair)
-                   (code-review--add-viewed-overlay (car pair)))))))))
+                   (code-review--add-viewed-overlay (car pair))))
+               (code-review-section--update-viewed-counter))))))
     (error
      (code-review-utils--log "code-review-section-fetch-viewed-files"
                             (format "Error: %S" err)))))

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1676,9 +1676,9 @@ If you want to display a minibuffer MSG in the end."
             raw-infos-complete)))
 
     (when errors-complete-query
-      (message "GraphQL ERRORS: %s" (prin1-to-string errors-complete-query))
       (code-review-utils--log "code-review--internal-build"
-                        (format "Data returned by GraphQL API: \n %s" (prin1-to-string res))))
+                        (format "Data returned by GraphQL API: \n %s" (prin1-to-string res)))
+      (message "GraphQL Github data contains errors. See `code-review-log-file' for details."))
 
     ;; verify must have value!
     (let-alist raw-infos

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -394,8 +394,11 @@ that repository.  Returns nil if no suitable remote found."
   "Get auth marker for OWNER/REPO.
 Checks git remotes for SSH host suffix matching the repository.
 Falls back to `code-review-auth-login-marker'."
-  (or (code-review-utils--auth-marker-from-remote owner repo)
-      code-review-auth-login-marker))
+  (let ((marker (or (code-review-utils--auth-marker-from-remote owner repo)
+                    code-review-auth-login-marker)))
+    (code-review-utils--log "code-review-utils--get-auth-marker"
+                            (format "owner=%s repo=%s marker=%S" owner repo marker))
+    marker))
 
 ;;; Forge interface
 

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -201,7 +201,8 @@ using COMMENTS."
                                :path .path
                                :createdAt .createdAt
                                :updatedAt .updatedAt
-                               :line-type .line-type))
+                               :line-type .line-type
+                               :send? nil))
                              (t
                               (code-review-code-comment-section
                                :state state

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -202,6 +202,7 @@ using COMMENTS."
                                :createdAt .createdAt
                                :updatedAt .updatedAt
                                :line-type .line-type
+                               :line   .line
                                :send? nil))
                              (t
                               (code-review-code-comment-section

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -354,6 +354,49 @@ Return a value between 0 and 1."
   (/ (+ (* .2126 red) (* .7152 green) (* .0722 blue)) 256))
 
 
+;;; Multi-account auth
+
+(defun code-review-utils--parse-ssh-host-suffix (url)
+  "Extract auth marker suffix from SSH host alias in URL.
+E.g., \"git@github.com-capp:owner/repo.git\" → `capp'.
+Returns nil if no suffix found."
+  (when (string-match "\\\`\\(?:ssh://\\)?\\(?:[^@]+@\\)?\\([^:/]+\\)" url)
+    (let ((host (match-string 1 url)))
+      (when (string-match "-\\([^.-]+\\)\\\'" host)
+        (intern (match-string 1 host))))))
+
+(defun code-review-utils--auth-marker-from-remote (&optional owner repo)
+  "Determine auth marker from SSH host alias in git remotes.
+When OWNER and REPO are given, only consider remotes matching
+that repository.  Returns nil if no suitable remote found."
+  (let ((git-dir (locate-dominating-file default-directory ".git")))
+    (when git-dir
+      (with-temp-buffer
+        (let ((default-directory git-dir))
+          (call-process "git" nil t nil "remote" "-v"))
+        (goto-char (point-min))
+        (let ((result nil))
+          (while (and (not result) (not (eobp)))
+            (let* ((line (buffer-substring (line-beginning-position) (line-end-position)))
+                   (url-end (string-match "[ \t]\\(?:\\(?:fetch\\)\|\\(?:push\\)\\)\\\'" line))
+                   (url (when url-end (substring line 0 url-end))))
+              (when (and url
+                         (or (null owner) (null repo)
+                             (string-match (format "%s[:/]%s\\(?:\\.git\\)?\\\'"
+                                                   (regexp-quote owner)
+                                                   (regexp-quote repo))
+                                           url)))
+                (setq result (code-review-utils--parse-ssh-host-suffix url))))
+            (forward-line 1))
+          result)))))
+
+(defun code-review-utils--get-auth-marker (owner repo)
+  "Get auth marker for OWNER/REPO.
+Checks git remotes for SSH host suffix matching the repository.
+Falls back to `code-review-auth-login-marker'."
+  (or (code-review-utils--auth-marker-from-remote owner repo)
+      code-review-auth-login-marker))
+
 ;;; Forge interface
 
 (defun code-review-utils--alist-forge-at-point ()

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -430,18 +430,18 @@ Falls back to `code-review-auth-login-marker'."
 
 (defun code-review-utils--log (origin msg)
   "Log MSG from ORIGIN to error file."
-  (with-temp-file code-review-log-file
-    (when (not (file-exists-p code-review-log-file))
-      (write-file code-review-log-file))
-    (insert-file-contents code-review-log-file)
-    (goto-char (point-max))
-    (insert ?\n)
-    (insert (current-time-string))
-    (insert " - ")
-    (insert origin)
-    (insert " - ")
-    (insert msg)
-    (insert ?\n)))
+  (let ((line (format "%s - %s - %s\n" (current-time-string) origin msg)))
+    (condition-case nil
+        (let ((file code-review-log-file))
+          (make-directory (file-name-directory file) t)
+          (with-temp-buffer
+            (when (file-exists-p file)
+              (insert-file-contents file))
+            (goto-char (point-max))
+            (insert line)
+            (write-region (point-min) (point-max) file nil 'silent)))
+      (error nil))))
+
 
 ;;; DIFF
 

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -540,5 +540,19 @@ Expect the same output as `git diff --no-prefix`"
            t)))
      labels)))
 
+;;;###autoload
+(defun code-review-utils--file-path-at-point ()
+  "Get file path from the magit file section at point.
+Returns nil if point is not on a file section."
+  (when-let* ((section (magit-current-section))
+              (file-section
+               (if (eq (oref section type) 'file) section
+                 (cl-loop for p = (oref section parent) then (oref p parent)
+                          while p
+                          when (eq (oref p type) 'file) return p)))
+              (value (oref file-section value)))
+    (if (stringp value) value
+      (car-safe value))))
+
 (provide 'code-review-utils)
 ;;; code-review-utils.el ends here

--- a/code-review-utils.el
+++ b/code-review-utils.el
@@ -203,6 +203,7 @@ using COMMENTS."
                                :updatedAt .updatedAt
                                :line-type .line-type
                                :line   .line
+                               :end-line .end-line
                                :send? nil))
                              (t
                               (code-review-code-comment-section

--- a/code-review.el
+++ b/code-review.el
@@ -156,7 +156,8 @@ OUTDATED."
    ("s m" "Milestone" code-review-set-milestone)
    ("s l" "Labels" code-review-set-label)
    ("s t" "Title" code-review-set-title)
-   ("s d" "Description" code-review-set-description)]
+   ("s d" "Description" code-review-set-description)
+   ("s v" "Toggle Viewed" code-review-toggle-file-viewed)]
   ["Buffer"
    ("G" "Full reload" code-review-reload)
    ("q" "Quit" transient-quit-one)])
@@ -168,6 +169,7 @@ OUTDATED."
     (define-key map (kbd "RET") 'code-review-comment-add-or-edit)
     (define-key map (kbd "C-c RET") 'code-review-submit-single-diff-comment-at-point)
     (define-key map (kbd "C-c C-s") 'code-review-comment-code-suggestion)
+    (define-key map (kbd "v") 'code-review-toggle-file-viewed)
     (define-key map (kbd "G") 'code-review-reload)
     (set-keymap-parent map magit-section-mode-map)
     map))


### PR DESCRIPTION
Adds the ability to mark files as "viewed" during code review, with real-time sync to GitHub via markFileAsViewed/unmarkFileAsViewed GraphQL mutations.

- Press v on any file in the diff to toggle viewed state
- Viewed files show a green checkmark
- Previously viewed files load from GitHub on PR open
- Header shows [N/total viewed] counter
- Also accessible via r → s v in transient menu